### PR TITLE
style(UI): 引入 shadcn 风格语义 token 并统一核心组件样式

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -48,7 +48,7 @@
               >
                 <n-back-top
                   :bottom="music.getPlaylists[0] && music.showPlayBar ? 100 : 40"
-                  style="transition: all 0.3s; z-index: 999"
+                  style="transition: all var(--duration-300) var(--ease-out); z-index: 999"
                 />
                 <router-view v-slot="{ Component, route }">
                   <transition name="fade-scale" mode="out-in">
@@ -445,8 +445,8 @@ onBeforeUnmount(() => {
 
 .main-content {
   transition:
-    transform 0.3s,
-    opacity 0.3s;
+    transform var(--duration-300) var(--ease-out),
+    opacity var(--duration-300) var(--ease-out);
 
   .bigplayer-on {
     opacity: 0;

--- a/src/components/Comment/index.vue
+++ b/src/components/Comment/index.vue
@@ -98,7 +98,7 @@ const toLikeComment = () => {
 <style lang="scss" scoped>
 .v-enter-active,
 .v-leave-active {
-  transition: opacity 0.3s ease;
+  transition: opacity var(--duration-300) var(--ease-out);
 }
 
 .v-enter-from,
@@ -107,7 +107,7 @@ const toLikeComment = () => {
 }
 .comment {
   margin-bottom: 12px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   :deep(.n-card__content) {
     display: flex;
     flex-direction: row;
@@ -172,7 +172,7 @@ const toLikeComment = () => {
         .name {
           font-weight: bold;
           cursor: pointer;
-          transition: all 0.3s;
+          transition: all var(--duration-300) var(--ease-out);
           &:hover {
             color: var(--main-color);
           }
@@ -181,7 +181,7 @@ const toLikeComment = () => {
       .beReplied {
         width: 100%;
         padding: 4px 8px;
-        border-radius: 8px;
+        border-radius: var(--radius-md);
         background-color: var(--n-border-color);
         font-size: 13px;
         margin-top: 6px;
@@ -189,7 +189,7 @@ const toLikeComment = () => {
         .name {
           font-weight: bold;
           cursor: pointer;
-          transition: all 0.3s;
+          transition: all var(--duration-300) var(--ease-out);
           &:hover {
             color: var(--main-color);
           }
@@ -213,7 +213,7 @@ const toLikeComment = () => {
         .like {
           margin-left: auto;
           cursor: pointer;
-          transition: all 0.3s;
+          transition: all var(--duration-300) var(--ease-out);
           opacity: 0.6;
           &:hover {
             color: var(--main-color);
@@ -238,7 +238,7 @@ const toLikeComment = () => {
 .skeleton {
   width: 100%;
   height: 120px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   margin-bottom: 12px;
 }
 </style>

--- a/src/components/DataList/AllArtists.vue
+++ b/src/components/DataList/AllArtists.vue
@@ -56,7 +56,7 @@ const jumpArtist = (id) => {
   flex-wrap: wrap;
   .name {
     cursor: pointer;
-    transition: all 0.3s;
+    transition: all var(--duration-300) var(--ease-out);
     &:hover {
       color: var(--main-color);
     }

--- a/src/components/DataList/ArtistLists.vue
+++ b/src/components/DataList/ArtistLists.vue
@@ -71,7 +71,7 @@
     </Transition>
     <!-- 右键菜单 -->
     <n-dropdown
-      style="--n-font-size: 14px; --n-border-radius: 6px"
+      style="--n-font-size: 14px; --n-border-radius: var(--radius-sm)"
       placement="bottom-start"
       trigger="manual"
       size="large"
@@ -243,7 +243,7 @@ onMounted(() => {
   padding-top: 20px;
   .v-enter-active,
   .v-leave-active {
-    transition: opacity 0.3s ease;
+    transition: opacity var(--duration-300) var(--ease-out);
   }
 
   .v-enter-from,
@@ -260,13 +260,13 @@ onMounted(() => {
       justify-content: center;
       box-shadow: 0 4px 16px 0 #00000020;
       border-radius: 50%;
-      transition: all 0.3s;
+      transition: all var(--duration-300) var(--ease-out);
       .coverImg {
         filter: brightness(1);
         transform: scale(1);
         width: 100%;
         height: 100%;
-        transition: all 0.3s;
+        transition: all var(--duration-300) var(--ease-out);
         z-index: 1;
         .cover-loading {
           position: relative;
@@ -298,14 +298,14 @@ onMounted(() => {
         z-index: 0;
         background-size: cover;
         aspect-ratio: 1/1;
-        transition: opacity 0.3s;
+        transition: opacity var(--duration-300) var(--ease-out);
       }
       .n-icon {
         opacity: 0;
         transform: scale(0.8);
         position: absolute;
         color: #fff;
-        transition: all 0.3s;
+        transition: all var(--duration-300) var(--ease-out);
         z-index: 1;
       }
       &:hover {
@@ -331,7 +331,7 @@ onMounted(() => {
     .name {
       margin-top: 14px;
       font-size: 16px;
-      transition: all 0.3s;
+      transition: all var(--duration-300) var(--ease-out);
       cursor: pointer;
       &:hover {
         color: var(--main-color);

--- a/src/components/DataList/CoverLists.vue
+++ b/src/components/DataList/CoverLists.vue
@@ -430,13 +430,13 @@ onMounted(() => {
       align-items: center;
       justify-content: center;
       position: relative;
-      border-radius: 8px;
+      border-radius: var(--radius-md);
       cursor: pointer;
       transition:
         transform var(--duration-200) var(--ease-out),
         box-shadow var(--duration-200) var(--ease-out);
       .coverImg {
-        border-radius: 8px;
+        border-radius: var(--radius-md);
         width: 100%;
         height: 100%;
         overflow: hidden;
@@ -504,8 +504,8 @@ onMounted(() => {
         -webkit-backdrop-filter: blur(4px);
         backdrop-filter: blur(4px);
         padding: 6px;
-        border-top-left-radius: 8px;
-        border-bottom-right-radius: 8px;
+        border-top-left-radius: var(--radius-md);
+        border-bottom-right-radius: var(--radius-md);
         transition:
           opacity var(--duration-150) var(--ease-in-out),
           transform var(--duration-150) var(--ease-in-out);
@@ -524,9 +524,7 @@ onMounted(() => {
       }
       &:hover {
         transform: translateY(-2px);
-        box-shadow:
-          0 8px 24px rgb(0 0 0 / 0.12),
-          0 2px 6px rgb(0 0 0 / 0.08);
+        box-shadow: var(--shadow-3);
         .coverImg {
           filter: brightness(0.72);
           :deep(img) {
@@ -587,7 +585,7 @@ onMounted(() => {
       padding-bottom: 100%;
       width: 100%;
       height: 0;
-      border-radius: 8px !important;
+      border-radius: var(--radius-md) !important;
       margin-bottom: 12px;
     }
   }

--- a/src/components/DataList/CoverLists.vue
+++ b/src/components/DataList/CoverLists.vue
@@ -87,7 +87,7 @@
     </Transition>
     <!-- 右键菜单 -->
     <n-dropdown
-      style="--n-font-size: 14px; --n-border-radius: 6px"
+      style="--n-font-size: 14px; --n-border-radius: var(--radius-sm)"
       placement="bottom-start"
       trigger="manual"
       size="large"

--- a/src/components/DataList/DataLists.vue
+++ b/src/components/DataList/DataLists.vue
@@ -849,7 +849,7 @@ const jumpLink = (id, type) => {
   }
 
   .songs {
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     margin-bottom: 12px;
     overflow: hidden;
     transition:
@@ -902,7 +902,7 @@ const jumpLink = (id, type) => {
       width: 50px;
       height: 50px;
       min-width: 50px;
-      border-radius: 8px;
+      border-radius: var(--radius-md);
       margin-right: 16px;
       display: flex;
       align-items: center;

--- a/src/components/DataList/SmallSongData.vue
+++ b/src/components/DataList/SmallSongData.vue
@@ -106,14 +106,14 @@ onMounted(() => {
   align-items: center;
   .pic {
     margin-right: 12px;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     min-width: 48px;
   }
   .name {
     line-height: 1.6;
     .n-text {
       font-size: 18px;
-      transition: all 0.3s;
+      transition: all var(--duration-300) var(--ease-out);
       cursor: pointer;
       &:hover {
         color: var(--main-color);

--- a/src/components/DataList/VideoLists.vue
+++ b/src/components/DataList/VideoLists.vue
@@ -87,7 +87,7 @@ const props = defineProps({
 .videolists {
   .v-enter-active,
   .v-leave-active {
-    transition: opacity 0.3s ease;
+    transition: opacity var(--duration-300) var(--ease-out);
   }
 
   .v-enter-from,
@@ -103,14 +103,14 @@ const props = defineProps({
       justify-content: center;
       position: relative;
       overflow: hidden;
-      border-radius: 8px;
+      border-radius: var(--radius-md);
       cursor: pointer;
-      transition: all 0.3s;
+      transition: all var(--duration-300) var(--ease-out);
       .coverImg {
-        border-radius: 8px;
+        border-radius: var(--radius-md);
         width: 100%;
         height: 100%;
-        transition: all 0.3s;
+        transition: all var(--duration-300) var(--ease-out);
       }
       .play {
         opacity: 0;
@@ -122,7 +122,7 @@ const props = defineProps({
         backdrop-filter: blur(10px);
         border-radius: 50%;
         transform: scale(0.8);
-        transition: all 0.3s;
+        transition: all var(--duration-300) var(--ease-out);
       }
       .num,
       .time {
@@ -133,14 +133,14 @@ const props = defineProps({
         -webkit-backdrop-filter: blur(4px);
         backdrop-filter: blur(4px);
         padding: 4px 8px;
-        transition: all 0.3s;
+        transition: all var(--duration-300) var(--ease-out);
       }
       .num {
         display: flex;
         align-items: center;
         top: 0;
         right: 0;
-        border-bottom-left-radius: 8px;
+        border-bottom-left-radius: var(--radius-md);
         .n-icon {
           margin-right: 4px;
         }
@@ -148,7 +148,7 @@ const props = defineProps({
       .time {
         left: 0;
         bottom: 0;
-        border-top-right-radius: 8px;
+        border-top-right-radius: var(--radius-md);
       }
       &:hover {
         box-shadow: 0 15px 30px rgb(0 0 0 / 10%);
@@ -176,7 +176,7 @@ const props = defineProps({
         // font-size: 2vh;
         font-size: 15px;
         -webkit-line-clamp: 2;
-        transition: all 0.3s;
+        transition: all var(--duration-300) var(--ease-out);
         cursor: pointer;
         &:hover {
           opacity: 1;
@@ -186,7 +186,7 @@ const props = defineProps({
       .by {
         font-size: 12px;
         opacity: 0.6;
-        transition: all 0.3s;
+        transition: all var(--duration-300) var(--ease-out);
         cursor: pointer;
         &:hover {
           opacity: 1;
@@ -202,7 +202,7 @@ const props = defineProps({
     .pic {
       height: 120px;
       width: 100%;
-      border-radius: 8px !important;
+      border-radius: var(--radius-md) !important;
       margin-bottom: 12px;
     }
   }

--- a/src/components/DataModal/AddPlaylist.vue
+++ b/src/components/DataModal/AddPlaylist.vue
@@ -117,7 +117,7 @@ defineExpose({
 .add-playlist {
   .v-enter-active,
   .v-leave-active {
-    transition: opacity 0.3s ease;
+    transition: opacity var(--duration-300) var(--ease-out);
   }
 
   .v-enter-from,
@@ -129,9 +129,9 @@ defineExpose({
       display: flex;
       align-items: center;
       padding: 12px;
-      border-radius: 8px;
+      border-radius: var(--radius-md);
       cursor: pointer;
-      transition: all 0.3s;
+      transition: all var(--duration-300) var(--ease-out);
       &:hover {
         background-color: var(--n-border-color);
       }

--- a/src/components/DataModal/DownloadSong.vue
+++ b/src/components/DataModal/DownloadSong.vue
@@ -234,7 +234,7 @@ defineExpose({
 .downloadModal {
   .v-enter-active,
   .v-leave-active {
-    transition: opacity 0.3s ease;
+    transition: opacity var(--duration-300) var(--ease-out);
   }
 
   .v-enter-from,

--- a/src/components/DataModal/ListenTogetherModal.vue
+++ b/src/components/DataModal/ListenTogetherModal.vue
@@ -473,7 +473,7 @@ async function copyShareLink() {
   padding-top: 18px;
 
   .auth-alert {
-    border-radius: 8px;
+    border-radius: var(--radius-md);
   }
 
   .empty-hint {
@@ -488,7 +488,7 @@ async function copyShareLink() {
   gap: 14px;
   padding: 12px 14px;
   background-color: var(--n-action-color);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--n-divider-color);
 
   .song-cover-wrap {
@@ -496,13 +496,13 @@ async function copyShareLink() {
     flex-shrink: 0;
     width: 56px;
     height: 56px;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     overflow: visible;
 
     .song-cover-img {
       width: 56px;
       height: 56px;
-      border-radius: 8px;
+      border-radius: var(--radius-md);
       object-fit: cover;
       display: block;
     }
@@ -558,7 +558,7 @@ async function copyShareLink() {
   justify-content: space-between;
   gap: 12px;
   padding: 14px 16px;
-  border-radius: 12px;
+  border-radius: var(--radius-panel);
   background: linear-gradient(
     135deg,
     color-mix(in srgb, var(--main-color) 12%, transparent),
@@ -599,7 +599,7 @@ async function copyShareLink() {
 
     .icon-btn {
       color: var(--n-text-color-3);
-      transition: color 0.2s;
+      transition: color var(--duration-200) var(--ease-out);
 
       &:hover {
         color: var(--main-color);
@@ -619,10 +619,10 @@ async function copyShareLink() {
   align-items: center;
   gap: 8px;
   padding: 7px 12px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   font-size: 12px;
   font-weight: 500;
-  transition: background-color 0.3s;
+  transition: background-color var(--duration-300) var(--ease-out);
 
   // idle / synced
   &.sync-bar--idle {
@@ -719,8 +719,8 @@ async function copyShareLink() {
   align-items: center;
   gap: 10px;
   padding: 7px 10px;
-  border-radius: 8px;
-  transition: background-color 0.15s;
+  border-radius: var(--radius-md);
+  transition: background-color var(--duration-150) var(--ease-out);
 
   &:hover {
     background-color: var(--n-action-color);
@@ -790,7 +790,7 @@ async function copyShareLink() {
 .now-playing-section {
   padding: 12px 14px;
   background-color: var(--n-action-color);
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--n-divider-color);
 }
 
@@ -822,10 +822,10 @@ async function copyShareLink() {
   flex-shrink: 0;
   width: 48px;
   height: 48px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   overflow: hidden;
   box-shadow: 0 3px 10px rgba(0, 0, 0, 0.18);
-  transition: border-radius 0.4s ease;
+  transition: border-radius var(--duration-400) var(--ease-out);
 
   &.np-cover--spinning {
     border-radius: 50%;
@@ -866,9 +866,9 @@ async function copyShareLink() {
 .lt-slide-enter-active,
 .lt-slide-leave-active {
   transition:
-    opacity 0.25s ease,
-    transform 0.25s ease,
-    max-height 0.3s ease;
+    opacity var(--duration-200) var(--ease-out),
+    transform var(--duration-200) var(--ease-out),
+    max-height var(--duration-300) var(--ease-out);
   overflow: hidden;
   max-height: 60px;
 }
@@ -882,7 +882,7 @@ async function copyShareLink() {
 
 .lt-fade-enter-active,
 .lt-fade-leave-active {
-  transition: opacity 0.2s ease;
+  transition: opacity var(--duration-200) var(--ease-out);
 }
 
 .lt-fade-enter-from,

--- a/src/components/DataModal/PlayListDrawer.vue
+++ b/src/components/DataModal/PlayListDrawer.vue
@@ -193,7 +193,7 @@ onBeforeUnmount(() => {
 .playlist-drawer {
   width: 400px !important;
   border-radius: 0;
-  transition: width 0.3s;
+  transition: width var(--duration-300) var(--ease-out);
 
   .n-drawer-header {
     height: 70px;
@@ -240,7 +240,7 @@ onBeforeUnmount(() => {
 .playlist-drawer {
   .v-enter-active,
   .v-leave-active {
-    transition: opacity 0.3s ease;
+    transition: opacity var(--duration-300) var(--ease-out);
   }
 
   .v-enter-from,
@@ -276,7 +276,7 @@ onBeforeUnmount(() => {
     border-radius: var(--radius-md);
     cursor: pointer;
     margin-bottom: 12px;
-    transition: all 0.3s;
+    transition: all var(--duration-300) var(--ease-out);
 
     &:nth-last-of-type(1) {
       margin-bottom: 0;
@@ -341,7 +341,7 @@ onBeforeUnmount(() => {
           height: 16px;
           background-color: var(--cover-main-color);
           border-radius: var(--radius-xs);
-          transition: all 0.3s;
+          transition: all var(--duration-300) var(--ease-out);
           animation: lineMove 1s ease-in-out infinite;
         }
 
@@ -385,7 +385,7 @@ onBeforeUnmount(() => {
         border-radius: var(--radius-md);
         right: 0;
         opacity: 0;
-        transition: all 0.3s;
+        transition: all var(--duration-300) var(--ease-out);
         color: #999;
         padding: 6px;
 

--- a/src/components/DataModal/PlayListDrawer.vue
+++ b/src/components/DataModal/PlayListDrawer.vue
@@ -8,100 +8,37 @@
     :show-mask="false"
     :trap-focus="false"
     :block-scroll="false"
-    :style="{
-      '--cover-main-color': `rgb(${site.songPicColor})` || '#efefef',
-      '--cover-second-color': `rgba(${site.songPicColor}, 0.14)` || '#efefef14',
-    }"
     placement="right"
     to="body"
     @update:show="handleDrawerShowUpdate"
     @after-leave="handleDrawerAfterLeave"
   >
-    <n-drawer-content :native-scrollbar="false" closable>
+    <n-drawer-content
+      class="playlist-drawer-content"
+      :native-scrollbar="true"
+      :body-content-style="{ padding: 0, height: '100%' }"
+      closable
+    >
       <template #header>
-        <div class="playlist-header">
-          <div class="text">
-            <n-text class="name">{{ $t("general.name.playlists") }}</n-text>
-            <n-text class="num" :depth="3" v-if="music.getPlaylists.length > 0">
-              {{ $t("general.name.songSize", { size: music.getPlaylists.length }) }}
-            </n-text>
-          </div>
-          <button
-            v-if="music.getPlaylists.length"
-            class="playlist-clear"
-            type="button"
-            @click="music.clearPlaylists()"
-          >
-            {{ $t("player.queue.clear") }}
-          </button>
-        </div>
+        <n-text class="playlist-title">{{ $t("general.name.playlists") }}</n-text>
       </template>
-      <Transition mode="out-in">
-        <div v-if="music.getPlaylists[0]">
-          <n-card
-            hoverable
-            :class="index === music.persistData.playSongIndex ? 'songs play' : 'songs'"
-            :id="'playlist' + index"
-            :content-style="{
-              padding: '8px',
-              display: 'flex',
-              flexDirection: 'row',
-              alignItems: 'center',
-            }"
-            v-for="(item, index) in music.getPlaylists"
-            :key="item"
-            @click="changeIndex(index)"
-          >
-            <div class="left">
-              <n-text v-if="index !== music.persistData.playSongIndex" :depth="3" class="num">
-                {{ index + 1 }}
-              </n-text>
-              <div v-else class="bar">
-                <div
-                  v-for="item in 3"
-                  :key="item"
-                  class="line"
-                  :style="{
-                    animationDelay: `0.${item * item}s`,
-                    animationPlayState: music.getPlayState ? 'running' : 'paused',
-                    height: `${Math.floor(Math.random() * 7) + 10}px`,
-                  }"
-                />
-              </div>
-            </div>
-            <div class="right">
-              <div class="name text-hidden">{{ item.name }}</div>
-              <AllArtists class="text-hidden" :artistsData="item.artist" />
-              <n-icon
-                class="remove"
-                size="18"
-                :component="DeleteFour"
-                @click.stop="music.removeSong(index)"
-              />
-            </div>
-          </n-card>
-        </div>
-        <n-text v-else>{{ $t("other.playlistEmpty") }}</n-text>
-      </Transition>
+      <QueuePanel ref="queuePanelRef" />
     </n-drawer-content>
   </n-drawer>
 </template>
 
 <script setup>
-import { musicStore, siteStore } from "@/store";
-import { DeleteFour } from "@icon-park/vue-next";
+import { musicStore } from "@/store";
 import { PLAYLIST_DRAWER_MEDIA_QUERY } from "@/utils/playlistLayout";
-import { useI18n } from "vue-i18n";
-import AllArtists from "@/components/DataList/AllArtists.vue";
+import QueuePanel from "@/components/QueuePanel/index.vue";
 
-const { t } = useI18n();
 const music = musicStore();
-const site = siteStore();
 
 // 播放列表显隐
 const useDrawerLayout = ref(false);
 let drawerMediaQuery = null;
 const playListShow = ref(false);
+const queuePanelRef = ref(null);
 
 const handleDrawerAfterLeave = () => {
   if (useDrawerLayout.value && !playListShow.value && music.showPlayList) {
@@ -119,33 +56,10 @@ const handleDrawerShowUpdate = (show) => {
   }
 };
 
-// 改变播放索引
-const changeIndex = (index) => {
-  try {
-    music.selectPlaySongByIndex(index);
-  } catch (err) {
-    console.error(t("general.message.operationFailed"), err);
-    $message.error(t("general.message.operationFailed"));
-  }
-};
-
-// 监听播放列表显隐
-const timeOut = ref(null);
+// 打开时滚动到当前播放曲目
 const scrollToCurrentSong = () => {
   nextTick().then(() => {
-    if (playListShow.value && music.getPlaylists[0]) {
-      const el = document.getElementById(`playlist${music.persistData.playSongIndex}`);
-      if (el) {
-        timeOut.value = setTimeout(() => {
-          el.scrollIntoView({
-            behavior: "smooth",
-            block: "center",
-          });
-        }, 500);
-      }
-    } else {
-      clearTimeout(timeOut.value);
-    }
+    if (playListShow.value) queuePanelRef.value?.scrollToCurrent();
   });
 };
 
@@ -185,7 +99,6 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   drawerMediaQuery?.removeEventListener("change", syncDrawerLayout);
-  clearTimeout(timeOut.value);
 });
 </script>
 
@@ -196,37 +109,14 @@ onBeforeUnmount(() => {
   transition: width var(--duration-300) var(--ease-out);
 
   .n-drawer-header {
-    height: 70px;
+    height: 60px;
     box-sizing: border-box;
   }
 
-  .n-scrollbar-content {
-    padding: 16px !important;
+  // QueuePanel 自管滚动与内边距，抽屉主体不再包滚动容器
+  .n-drawer-body-content-wrapper {
+    padding: 0 !important;
     height: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-  }
-
-  &.full-player {
-    background-color: transparent;
-    box-shadow: none;
-
-    .n-drawer-header {
-      border-bottom: none;
-
-      .pl-name {
-        a,
-        span,
-        .n-icon {
-          color: var(--cover-main-color) !important;
-        }
-      }
-
-      .n-base-icon {
-        color: var(--cover-main-color);
-      }
-    }
   }
 
   @media (max-width: 700px) {
@@ -237,186 +127,8 @@ onBeforeUnmount(() => {
 </style>
 
 <style lang="scss" scoped>
-.playlist-drawer {
-  .v-enter-active,
-  .v-leave-active {
-    transition: opacity var(--duration-300) var(--ease-out);
-  }
-
-  .v-enter-from,
-  .v-leave-to {
-    opacity: 0;
-  }
-
-  .playlist-header {
-    width: 100%;
-    min-width: 0;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-  }
-
-  .text {
-    min-width: 0;
-    display: flex;
-    align-items: center;
-
-    .num {
-      font-size: 14px;
-
-      &::before {
-        content: "-";
-        margin: 0 6px;
-      }
-    }
-  }
-
-  .songs {
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    margin-bottom: 12px;
-    transition: all var(--duration-300) var(--ease-out);
-
-    &:nth-last-of-type(1) {
-      margin-bottom: 0;
-    }
-
-    &:active {
-      transform: scale(0.98);
-    }
-
-    &:hover {
-      .n-card__content {
-        .right {
-          .remove {
-            opacity: 1;
-          }
-        }
-      }
-    }
-
-    &.play {
-      background-color: var(--cover-second-color);
-      border-color: var(--cover-main-color);
-
-      a,
-      span,
-      div,
-      .n-icon {
-        color: var(--cover-main-color);
-      }
-
-      :deep(span) {
-        color: var(--cover-main-color);
-      }
-
-      .right {
-        .remove {
-          color: var(--cover-main-color);
-
-          &:hover {
-            background-color: var(--n-action-color);
-          }
-        }
-      }
-    }
-
-    .left {
-      width: 30px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      margin-right: 12px;
-
-      .bar {
-        display: flex;
-        justify-content: space-evenly;
-        align-items: flex-end;
-        width: 20px;
-        height: 20px;
-
-        .line {
-          width: 3px;
-          height: 16px;
-          background-color: var(--cover-main-color);
-          border-radius: var(--radius-xs);
-          transition: all var(--duration-300) var(--ease-out);
-          animation: lineMove 1s ease-in-out infinite;
-        }
-
-        @keyframes lineMove {
-          0% {
-            height: 16px;
-          }
-
-          50% {
-            height: 10px;
-          }
-
-          100% {
-            height: 16px;
-          }
-        }
-      }
-    }
-
-    .right {
-      flex: 1;
-      position: relative;
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      justify-content: center;
-      padding-right: 42px;
-
-      .name {
-        pointer-events: none;
-      }
-
-      .artists {
-        opacity: 0.8;
-        font-size: 13px;
-        pointer-events: none;
-      }
-
-      .remove {
-        position: absolute;
-        border-radius: var(--radius-md);
-        right: 0;
-        opacity: 0;
-        transition: all var(--duration-300) var(--ease-out);
-        color: #999;
-        padding: 6px;
-
-        &:hover {
-          color: var(--cover-main-color);
-          background-color: var(--n-border-color);
-        }
-      }
-    }
-  }
-
-  .playlist-clear {
-    flex: 0 0 auto;
-    padding: 5px 9px;
-    border: 0;
-    border-radius: var(--radius-sm);
-    color: var(--n-text-color-3);
-    background: transparent;
-    font: inherit;
-    font-size: 12px;
-    cursor: pointer;
-    transition:
-      color 0.16s ease,
-      background-color 0.16s ease;
-
-    &:hover,
-    &:focus-visible {
-      color: var(--n-text-color);
-      background-color: color-mix(in srgb, var(--n-text-color) 9%, transparent);
-      outline: none;
-    }
-  }
+.playlist-title {
+  font-size: 15px;
+  font-weight: 700;
 }
 </style>

--- a/src/components/Nav/index.vue
+++ b/src/components/Nav/index.vue
@@ -128,12 +128,12 @@ nav {
         padding: 3px;
         cursor: pointer;
         transition:
-          background-color 0.2s,
-          transform 0.2s;
+          background-color var(--duration-200) var(--ease-out),
+          transform var(--duration-200) var(--ease-out);
 
         @media (min-width: 640px) {
           &:hover {
-            background-color: rgba(0, 0, 0, 0.05);
+            background-color: var(--hover-overlay);
           }
         }
 
@@ -173,12 +173,12 @@ nav {
       -webkit-backdrop-filter: blur(18px) saturate(160%);
       backdrop-filter: blur(18px) saturate(160%);
       transition:
-        background-color 0.2s,
-        transform 0.2s,
-        color 0.2s;
+        background-color var(--duration-200) var(--ease-out),
+        transform var(--duration-200) var(--ease-out),
+        color var(--duration-200) var(--ease-out);
 
       &:hover {
-        background-color: rgba(0, 0, 0, 0.05);
+        background-color: var(--hover-overlay);
       }
 
       &:active {

--- a/src/components/Personalized/PaPersonalFm.vue
+++ b/src/components/Personalized/PaPersonalFm.vue
@@ -193,7 +193,7 @@ onMounted(() => {
   z-index: 2;
   background: rgba(14, 14, 15, 0.72);
   border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
 }
@@ -295,13 +295,13 @@ onMounted(() => {
   padding: 0;
   color: inherit;
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   cursor: pointer;
   transition:
-    color 160ms ease,
-    background-color 160ms ease,
-    border-color 160ms ease,
-    transform 160ms ease;
+    color var(--duration-150) ease,
+    background-color var(--duration-150) ease,
+    border-color var(--duration-150) ease,
+    transform var(--duration-150) ease;
 }
 
 .control-button:hover {

--- a/src/components/Player/BigPlayer/BigPlayerBackground.vue
+++ b/src/components/Player/BigPlayer/BigPlayerBackground.vue
@@ -69,7 +69,8 @@ const grayStyles = computed(() => ({
   backgroundColor: "#00000030",
   WebkitBackdropFilter: "blur(80px)",
   backdropFilter: "blur(80px)",
-  transition: "backdrop-filter 0.5s ease, background-color 0.5s ease",
+  transition:
+    "backdrop-filter var(--duration-500) var(--ease-out), background-color var(--duration-500) var(--ease-out)",
 }));
 </script>
 
@@ -125,7 +126,7 @@ const grayStyles = computed(() => ({
 
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: opacity var(--duration-300) cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .fade-enter-from,

--- a/src/components/Player/BigPlayer/BigPlayerTopBar.vue
+++ b/src/components/Player/BigPlayer/BigPlayerTopBar.vue
@@ -63,8 +63,8 @@ defineEmits<{
       justify-content: center;
       font-size: 40px;
       opacity: 0.3;
-      border-radius: 8px;
-      transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+      border-radius: var(--radius-md);
+      transition: all var(--duration-300) cubic-bezier(0.34, 1.56, 0.64, 1);
       cursor: pointer;
       will-change: transform, opacity, background-color;
 

--- a/src/components/Player/BigPlayer/DesktopQueuePanel.vue
+++ b/src/components/Player/BigPlayer/DesktopQueuePanel.vue
@@ -149,7 +149,7 @@ onBeforeUnmount(() => {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   padding: 18px 14px 14px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   color: var(--main-cover-color);
   background: rgba(20, 20, 20, 0.2);
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -185,7 +185,7 @@ onBeforeUnmount(() => {
   flex: 0 0 auto;
   padding: 6px 10px;
   border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   color: inherit;
   background: rgba(255, 255, 255, 0.06);
   font: inherit;
@@ -260,7 +260,7 @@ onBeforeUnmount(() => {
   grid-template-columns: 30px 48px minmax(0, 1fr) auto 36px;
   align-items: center;
   gap: 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   padding: 8px 8px 8px 4px;
   margin-bottom: 8px;
   box-sizing: border-box;
@@ -369,8 +369,8 @@ onBeforeUnmount(() => {
   opacity: 0;
   cursor: pointer;
   transition:
-    opacity 0.2s ease,
-    background-color 0.2s ease,
+    opacity var(--duration-200) var(--ease-out),
+    background-color var(--duration-200) var(--ease-out),
     transform 0.18s ease;
 
   &:hover,

--- a/src/components/Player/BigPlayer/DesktopQueuePanel.vue
+++ b/src/components/Player/BigPlayer/DesktopQueuePanel.vue
@@ -25,7 +25,7 @@
       ref="queueListRef"
       class="queue-list"
       :items="queueRows"
-      :item-size="73"
+      :item-size="52"
       :item-resizable="true"
       key-field="key"
       :show-scrollbar="false"
@@ -33,7 +33,16 @@
       <template #default="{ item: row }">
         <div
           :id="`desktop-queue-${row.index}`"
-          :class="['queue-song', { 'is-current': row.index === music.persistData.playSongIndex }]"
+          :class="[
+            'queue-song',
+            {
+              'is-current': row.index === music.persistData.playSongIndex,
+              'row-odd': row.index % 2 === 0,
+              'row-even': row.index % 2 === 1,
+              'row-first': row.index === 0,
+              'row-last': row.index === music.getPlaylists.length - 1,
+            },
+          ]"
           role="button"
           tabindex="0"
           @click="changeQueueIndex(row.index)"
@@ -54,7 +63,7 @@
           </div>
           <div class="queue-duration" v-if="row.item.time">{{ row.item.time }}</div>
           <button class="queue-remove" type="button" @click.stop="music.removeSong(row.index)">
-            <n-icon size="20" :component="DeleteRound" />
+            <n-icon size="17" :component="DeleteRound" />
           </button>
         </div>
       </template>
@@ -254,39 +263,46 @@ onBeforeUnmount(() => {
   }
 }
 
+// 与 QueuePanel / HistoryView 一致的斑马纹连续列表，仅将中性色换成
+// 封面自适应的 --main-cover-color（面板叠在专辑封面之上）
 .queue-song {
-  min-height: 64px;
+  min-height: 52px;
   display: grid;
-  grid-template-columns: 30px 48px minmax(0, 1fr) auto 36px;
+  grid-template-columns: 26px 38px minmax(0, 1fr) auto 28px;
   align-items: center;
   gap: 10px;
-  border-radius: var(--radius-md);
-  padding: 8px 8px 8px 4px;
-  margin-bottom: 8px;
+  border-radius: 0;
+  padding: 6px 8px;
   box-sizing: border-box;
-  background: rgba(255, 255, 255, 0.075);
-  border: 1px solid rgba(255, 255, 255, 0.08);
   cursor: pointer;
-  transition:
-    background-color 0.22s ease,
-    border-color 0.22s ease,
-    transform 0.18s ease;
+  transition: background-color var(--duration-150) var(--ease-out);
+
+  &.row-first {
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+  }
+
+  &.row-last {
+    border-radius: 0 0 var(--radius-md) var(--radius-md);
+  }
+
+  &.row-odd {
+    background: color-mix(in srgb, var(--main-cover-color) 5%, transparent);
+  }
+
+  &.row-even {
+    background: color-mix(in srgb, var(--main-cover-color) 9%, transparent);
+  }
 
   &:hover {
-    background: rgba(255, 255, 255, 0.115);
+    background: color-mix(in srgb, var(--main-cover-color) 14%, transparent);
 
     .queue-remove {
       opacity: 0.82;
     }
   }
 
-  &:active {
-    transform: scale(0.985);
-  }
-
   &.is-current {
-    background: color-mix(in srgb, var(--main-cover-color) 18%, transparent);
-    border-color: color-mix(in srgb, var(--main-cover-color) 42%, transparent);
+    background: color-mix(in srgb, var(--main-cover-color) 22%, transparent);
   }
 }
 
@@ -325,11 +341,10 @@ onBeforeUnmount(() => {
 }
 
 .queue-cover {
-  width: 48px;
-  height: 48px;
-  border-radius: 7px;
+  width: 38px;
+  height: 38px;
+  border-radius: var(--radius-sm);
   object-fit: cover;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.24);
 }
 
 .queue-info {
@@ -337,13 +352,13 @@ onBeforeUnmount(() => {
 
   .queue-name {
     font-weight: 650;
-    font-size: 0.95rem;
-    line-height: 1.2;
+    font-size: 0.85rem;
+    line-height: 1.25;
   }
 
   .queue-artists {
-    margin-top: 5px;
-    font-size: 0.78rem;
+    margin-top: 2px;
+    font-size: 0.75rem;
     opacity: 0.62;
   }
 }
@@ -359,9 +374,9 @@ onBeforeUnmount(() => {
   border: none;
   background: transparent;
   color: var(--main-cover-color);
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
   padding: 0;
   display: flex;
   align-items: center;
@@ -370,17 +385,12 @@ onBeforeUnmount(() => {
   cursor: pointer;
   transition:
     opacity var(--duration-200) var(--ease-out),
-    background-color var(--duration-200) var(--ease-out),
-    transform 0.18s ease;
+    background-color var(--duration-200) var(--ease-out);
 
   &:hover,
   &:focus-visible {
     opacity: 1;
-    background: rgba(255, 255, 255, 0.14);
-  }
-
-  &:active {
-    transform: scale(0.94);
+    background: color-mix(in srgb, var(--main-cover-color) 14%, transparent);
   }
 }
 

--- a/src/components/Player/BigPlayer/DesktopRecordMenu.vue
+++ b/src/components/Player/BigPlayer/DesktopRecordMenu.vue
@@ -96,7 +96,7 @@ const setting = settingStore();
   display: flex !important;
   justify-content: center;
   align-items: center;
-  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: all var(--duration-300) cubic-bezier(0.34, 1.56, 0.64, 1);
   flex-direction: column;
   will-change: opacity;
 
@@ -142,7 +142,7 @@ const setting = settingStore();
         --n-text-color-pressed: var(--main-cover-color);
         --n-border: none;
         border: none;
-        transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+        transition: all var(--duration-300) cubic-bezier(0.34, 1.56, 0.64, 1);
         will-change: transform, background-color;
 
         &:hover {
@@ -164,11 +164,11 @@ const setting = settingStore();
       --n-height: 42px;
       color: var(--main-cover-color);
       margin: 0 12px;
-      transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+      transition: all var(--duration-300) cubic-bezier(0.34, 1.56, 0.64, 1);
       will-change: transform, background-color;
 
       .n-icon {
-        transition: all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+        transition: all var(--duration-200) cubic-bezier(0.34, 1.56, 0.64, 1);
         color: var(--main-cover-color);
         will-change: transform, opacity;
       }
@@ -191,9 +191,9 @@ const setting = settingStore();
     font-size: 24px;
     cursor: pointer;
     padding: 8px;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     opacity: 0.4;
-    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    transition: all var(--duration-300) cubic-bezier(0.34, 1.56, 0.64, 1);
     will-change: transform, opacity, background-color;
 
     &:hover {
@@ -213,7 +213,7 @@ const setting = settingStore();
 
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: opacity var(--duration-300) cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .fade-enter-from,

--- a/src/components/Player/BigPlayer/DesktopToggleControls.vue
+++ b/src/components/Player/BigPlayer/DesktopToggleControls.vue
@@ -68,7 +68,7 @@ defineEmits<{
   width: 3rem;
   height: 3rem;
   padding: 0;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition:
     opacity 0.24s ease,

--- a/src/components/Player/BigPlayer/LyricOffsetControl.vue
+++ b/src/components/Player/BigPlayer/LyricOffsetControl.vue
@@ -70,8 +70,8 @@ const resetOffset = () => {
   opacity: 0;
   pointer-events: none;
   transition:
-    opacity 0.25s ease,
-    visibility 0.25s ease;
+    opacity var(--duration-200) var(--ease-out),
+    visibility var(--duration-200) var(--ease-out);
 
   // When offset ≠ 0: show only the badge
   &.has-offset .offset-value {
@@ -115,10 +115,10 @@ const resetOffset = () => {
   visibility: hidden;
   opacity: 0;
   transition:
-    opacity 0.2s ease,
-    visibility 0.2s ease,
-    background-color 0.15s ease,
-    transform 0.1s ease;
+    opacity var(--duration-200) var(--ease-out),
+    visibility var(--duration-200) var(--ease-out),
+    background-color var(--duration-150) var(--ease-out),
+    transform var(--duration-150) var(--ease-out);
 
   &:hover {
     opacity: 1 !important;
@@ -136,7 +136,7 @@ const resetOffset = () => {
   color: var(--main-cover-color);
   cursor: pointer;
   padding: 3px 8px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   white-space: nowrap;
   text-align: center;
   line-height: 1.2;
@@ -145,9 +145,9 @@ const resetOffset = () => {
   visibility: hidden;
   opacity: 0;
   transition:
-    opacity 0.2s ease,
-    visibility 0.2s ease,
-    background-color 0.15s ease;
+    opacity var(--duration-200) var(--ease-out),
+    visibility var(--duration-200) var(--ease-out),
+    background-color var(--duration-150) var(--ease-out);
 
   &:hover {
     opacity: 1 !important;

--- a/src/components/Player/BigPlayer/MobileControls.vue
+++ b/src/components/Player/BigPlayer/MobileControls.vue
@@ -115,8 +115,8 @@ const { persistData } = storeToRefs(music);
     color: var(--main-cover-color);
     cursor: pointer;
     transition:
-      transform 0.15s ease,
-      opacity 0.15s ease;
+      transform var(--duration-150) var(--ease-out),
+      opacity var(--duration-150) var(--ease-out);
 
     &:active {
       transform: scale(0.85);
@@ -195,7 +195,7 @@ const { persistData } = storeToRefs(music);
 
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: opacity var(--duration-300) cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .fade-enter-from,

--- a/src/components/Player/BigPlayer/MobileCoverFrame.vue
+++ b/src/components/Player/BigPlayer/MobileCoverFrame.vue
@@ -125,7 +125,7 @@ function onImgError(): void {
     // Start fully transparent; fade in once loaded so there is never a
     // jarring "snap" where the old artwork is replaced by a blank frame.
     opacity: 0;
-    transition: opacity 0.35s ease;
+    transition: opacity var(--duration-400) var(--ease-out);
 
     &.loaded {
       opacity: 1;
@@ -161,7 +161,7 @@ function onImgError(): void {
   // ── Shimmer fade-out transition ─────────────────────────────────────────────
 
   .shimmer-fade-leave-active {
-    transition: opacity 0.4s ease;
+    transition: opacity var(--duration-400) var(--ease-out);
   }
 
   .shimmer-fade-leave-to {

--- a/src/components/Player/BigPlayer/MobilePlayerLayout.vue
+++ b/src/components/Player/BigPlayer/MobilePlayerLayout.vue
@@ -214,7 +214,7 @@
             ref="queueListRef"
             class="mobile-queue-list"
             :items="queueRows"
-            :item-size="73"
+            :item-size="56"
             :item-resizable="true"
             key-field="key"
             :show-scrollbar="false"
@@ -225,7 +225,13 @@
                 :id="`mobile-queue-${row.index}`"
                 :class="[
                   'queue-song',
-                  { 'is-current': row.index === music.persistData.playSongIndex },
+                  {
+                    'is-current': row.index === music.persistData.playSongIndex,
+                    'row-odd': row.index % 2 === 0,
+                    'row-even': row.index % 2 === 1,
+                    'row-first': row.index === 0,
+                    'row-last': row.index === music.getPlaylists.length - 1,
+                  },
                 ]"
                 role="button"
                 tabindex="0"
@@ -1168,26 +1174,40 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
   }
 }
 
+// 与 QueuePanel / DesktopQueuePanel 一致的斑马纹连续列表（封面自适应色）
 .queue-song {
-  min-height: 64px;
+  min-height: 56px;
   display: grid;
-  grid-template-columns: 30px 48px minmax(0, 1fr) auto 36px;
+  grid-template-columns: 26px 42px minmax(0, 1fr) auto 32px;
   align-items: center;
   gap: 10px;
-  border-radius: var(--radius-md);
-  padding: 8px 8px 8px 4px;
-  margin-bottom: 8px;
+  border-radius: 0;
+  padding: 7px 8px;
   box-sizing: border-box;
-  background: rgba(255, 255, 255, 0.075);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition: background-color var(--duration-150) var(--ease-out);
+
+  &.row-first {
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+  }
+
+  &.row-last {
+    border-radius: 0 0 var(--radius-md) var(--radius-md);
+  }
+
+  &.row-odd {
+    background: color-mix(in srgb, var(--main-cover-color) 5%, transparent);
+  }
+
+  &.row-even {
+    background: color-mix(in srgb, var(--main-cover-color) 9%, transparent);
+  }
 
   &:active {
-    transform: scale(0.985);
+    background: color-mix(in srgb, var(--main-cover-color) 15%, transparent);
   }
 
   &.is-current {
-    background: color-mix(in srgb, var(--main-cover-color) 18%, transparent);
-    border-color: color-mix(in srgb, var(--main-cover-color) 42%, transparent);
+    background: color-mix(in srgb, var(--main-cover-color) 22%, transparent);
   }
 }
 
@@ -1226,11 +1246,10 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
 }
 
 .queue-cover {
-  width: 48px;
-  height: 48px;
-  border-radius: 7px;
+  width: 42px;
+  height: 42px;
+  border-radius: var(--radius-sm);
   object-fit: cover;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.24);
 }
 
 .queue-info {
@@ -1238,13 +1257,13 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
 
   .queue-name {
     font-weight: 650;
-    font-size: 0.95rem;
-    line-height: 1.2;
+    font-size: 0.88rem;
+    line-height: 1.25;
   }
 
   .queue-artists {
-    margin-top: 5px;
-    font-size: 0.78rem;
+    margin-top: 2px;
+    font-size: 0.75rem;
     opacity: 0.62;
   }
 }
@@ -1260,9 +1279,9 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
   border: none;
   background: transparent;
   color: var(--main-cover-color);
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
   padding: 0;
   display: flex;
   align-items: center;
@@ -1272,8 +1291,7 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
 
   &:active {
     opacity: 1;
-    background: rgba(255, 255, 255, 0.12);
-    transform: scale(0.94);
+    background: color-mix(in srgb, var(--main-cover-color) 14%, transparent);
   }
 }
 
@@ -1289,13 +1307,13 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
 
 @media (max-width: 380px) {
   .queue-song {
-    grid-template-columns: 26px 44px minmax(0, 1fr) 34px;
+    grid-template-columns: 24px 40px minmax(0, 1fr) 32px;
     gap: 8px;
   }
 
   .queue-cover {
-    width: 44px;
-    height: 44px;
+    width: 40px;
+    height: 40px;
   }
 
   .queue-duration {

--- a/src/components/Player/BigPlayer/MobilePlayerLayout.vue
+++ b/src/components/Player/BigPlayer/MobilePlayerLayout.vue
@@ -699,7 +699,7 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
     height: 5px;
     background: rgba(255, 255, 255, 0.3);
     border-radius: 3px;
-    transition: background 0.2s ease;
+    transition: background var(--duration-200) var(--ease-out);
   }
 
   &:active .handle-bar {
@@ -761,7 +761,7 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
   grid-row: controls;
   grid-column: info-side;
   align-self: center;
-  transition: opacity 0.25s 0.25s;
+  transition: opacity var(--duration-200) var(--ease-out) 0.25s;
   padding-left: 12px;
   min-width: 0;
   overflow: visible;
@@ -868,7 +868,7 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
 .mobile-lyric {
   grid-row: controls / -1;
   grid-column: 1 / -1;
-  transition: opacity 0.5s 0.5s;
+  transition: opacity var(--duration-500) var(--ease-out) 0.5s;
   opacity: 1;
   min-height: 0;
   position: relative;
@@ -925,7 +925,7 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: opacity 0.5s 0.5s;
+  transition: opacity var(--duration-500) var(--ease-out) 0.5s;
   opacity: 1;
 
   .mobile-ui-empty {
@@ -955,7 +955,7 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
 .mobile-big-controls {
   grid-row: controls-view;
   grid-column: 2 / 3;
-  transition: opacity 0.5s;
+  transition: opacity var(--duration-500) var(--ease-out);
   opacity: 0;
   min-width: 0;
   z-index: 2;
@@ -1099,7 +1099,7 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
   flex: 0 0 auto;
   padding: 6px 10px;
   border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   color: inherit;
   background: rgba(255, 255, 255, 0.06);
   font: inherit;
@@ -1174,7 +1174,7 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
   grid-template-columns: 30px 48px minmax(0, 1fr) auto 36px;
   align-items: center;
   gap: 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   padding: 8px 8px 8px 4px;
   margin-bottom: 8px;
   box-sizing: border-box;
@@ -1324,7 +1324,7 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
 // Default state (Layer 1 visible):
 .mobile-small-controls {
   opacity: 0;
-  transition: opacity 0.5s;
+  transition: opacity var(--duration-500) var(--ease-out);
   pointer-events: none;
 }
 
@@ -1335,7 +1335,7 @@ defineExpose({ phonyBigCoverRef, phonySmallCoverRef, nameWrapperRef, nameTextRef
 .mobile-lyric,
 .no-lyrics {
   opacity: 0;
-  transition: opacity 0.5s;
+  transition: opacity var(--duration-500) var(--ease-out);
   pointer-events: none;
 }
 

--- a/src/components/Player/BigPlayer/index.vue
+++ b/src/components/Player/BigPlayer/index.vue
@@ -1348,8 +1348,8 @@ defineExpose({
   transform: translateY(100%);
   border-radius: 1em 1em 0 0;
   transition:
-    border-radius 0.25s ease,
-    transform 0.5s cubic-bezier(0.25, 1, 0.5, 1);
+    border-radius var(--duration-200) var(--ease-out),
+    transform var(--duration-500) cubic-bezier(0.25, 1, 0.5, 1);
 
   // Opened state
   &.opened {
@@ -1357,8 +1357,8 @@ defineExpose({
     transform: translateY(0%);
     border-radius: 0;
     transition:
-      border-radius 0.25s 0.25s ease,
-      transform 0.5s cubic-bezier(0.25, 1, 0.5, 1);
+      border-radius var(--duration-200) var(--ease-out) 0.25s,
+      transform var(--duration-500) cubic-bezier(0.25, 1, 0.5, 1);
   }
 
   /* ═══════════════════════════════════════════════════════
@@ -1455,7 +1455,7 @@ defineExpose({
     // 默认: Layer 1 可见 (= AMLL hideLyric)
     :deep(.mobile-small-controls) {
       opacity: 0;
-      transition: opacity 0.5s;
+      transition: opacity var(--duration-500) var(--ease-out);
       pointer-events: none;
     }
 
@@ -1466,7 +1466,7 @@ defineExpose({
     :deep(.mobile-lyric),
     :deep(.no-lyrics) {
       opacity: 0;
-      transition: opacity 0.5s;
+      transition: opacity var(--duration-500) var(--ease-out);
       pointer-events: none;
     }
 
@@ -1486,7 +1486,7 @@ defineExpose({
     &.layer2-active {
       :deep(.mobile-small-controls) {
         opacity: 1;
-        transition: opacity 0.25s 0.25s;
+        transition: opacity var(--duration-200) var(--ease-out) 0.25s;
       }
 
       :deep(.mobile-cover-layout) {
@@ -1496,7 +1496,7 @@ defineExpose({
       :deep(.mobile-lyric),
       :deep(.no-lyrics) {
         opacity: 1;
-        transition: opacity 0.5s 0.5s;
+        transition: opacity var(--duration-500) var(--ease-out) 0.5s;
       }
 
       :deep(.mobile-big-controls) {
@@ -1550,7 +1550,7 @@ defineExpose({
 /* CSS过渡效果 */
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: opacity var(--duration-300) cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .fade-enter-from,

--- a/src/components/Player/ControlThumb.vue
+++ b/src/components/Player/ControlThumb.vue
@@ -100,7 +100,7 @@ const handlePointerLeave = () => {
     height: 8px;
     border: none;
     padding: 0;
-    border-radius: 4px;
+    border-radius: var(--radius-xs);
     background-color: color-mix(in srgb, currentColor 16%, transparent);
     color: inherit;
     cursor: none;
@@ -121,7 +121,7 @@ const handlePointerLeave = () => {
       height: 0;
       margin-top: 0;
       background-color: currentColor;
-      border-radius: 10px;
+      border-radius: var(--radius-lg);
       mix-blend-mode: plus-lighter;
       rotate: 0deg;
       transition:

--- a/src/components/Player/CountDown.vue
+++ b/src/components/Player/CountDown.vue
@@ -63,7 +63,7 @@ watch(
 <style lang="scss" scoped>
 .v-enter-active,
 .v-leave-active {
-  transition: all 0.3s ease-in-out;
+  transition: all var(--duration-300) var(--ease-in-out);
 }
 
 .v-enter-from,
@@ -76,7 +76,7 @@ watch(
   animation: breathe 5s ease-in-out infinite;
   .point {
     margin-right: 4px;
-    transition: all 0.3s;
+    transition: all var(--duration-300) var(--ease-out);
     &.hidden {
       opacity: 0.2;
     }

--- a/src/components/Player/ListenTogetherStatus.vue
+++ b/src/components/Player/ListenTogetherStatus.vue
@@ -54,9 +54,9 @@ defineEmits(["click"]);
   align-items: center;
   gap: 6px;
   padding: 4px 8px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
   color: var(--main-color);
   background-color: var(--main-color-hover);
 
@@ -107,7 +107,7 @@ defineEmits(["click"]);
       color: var(--main-color);
       background-color: var(--n-action-color);
       padding: 2px 6px;
-      border-radius: 4px;
+      border-radius: var(--radius-xs);
     }
   }
 

--- a/src/components/Player/PlayerCover.vue
+++ b/src/components/Player/PlayerCover.vue
@@ -416,10 +416,10 @@ onMounted(() => {
     position: relative;
     width: 100%;
     height: 100%;
-    border-radius: 12px;
+    border-radius: var(--radius-panel);
     transition:
-      transform 0.5s ease-out,
-      filter 0.5s ease-out;
+      transform var(--duration-500) var(--ease-out),
+      filter var(--duration-500) var(--ease-out);
     &.pause {
       transform: scale(0.95);
     }
@@ -430,7 +430,7 @@ onMounted(() => {
     .album {
       width: 100%;
       height: 100%;
-      border-radius: 12px;
+      border-radius: var(--radius-panel);
     }
   }
   .controls {
@@ -485,14 +485,14 @@ onMounted(() => {
           font-size: 1.75rem;
           cursor: pointer;
           opacity: 1;
-          transition: opacity 0.2s ease;
+          transition: opacity var(--duration-200) var(--ease-out);
         }
 
         .more-button {
           font-size: 1.75rem;
           cursor: pointer;
           opacity: 1;
-          transition: opacity 0.2s ease;
+          transition: opacity var(--duration-200) var(--ease-out);
           &:hover {
             opacity: 1;
           }
@@ -534,7 +534,7 @@ onMounted(() => {
           opacity: 1;
           font-size: 0.75rem;
           padding: 2px 8px;
-          border-radius: 4px;
+          border-radius: var(--radius-xs);
           white-space: nowrap;
           .wave-icon {
             width: 14px;
@@ -573,8 +573,8 @@ onMounted(() => {
         opacity: 1;
         cursor: pointer;
         transition:
-          opacity 0.2s ease,
-          transform 0.1s ease-out;
+          opacity var(--duration-200) var(--ease-out),
+          transform var(--duration-150) var(--ease-out);
         &:hover {
           opacity: 1;
         }

--- a/src/components/Player/PlayerCover.vue
+++ b/src/components/Player/PlayerCover.vue
@@ -385,21 +385,29 @@ onMounted(() => {
 
 <style lang="scss" scoped>
 .player-cover-container {
-  --cover-size: min(50vh, 38vw);
+  /* 高度预算：控件区约 15rem + 纵向 gap 2rem + 顶部关闭手柄余量 2.5rem */
+  --cover-controls-budget: 19.5rem;
+  --cover-size: max(10rem, min(50vh, 38vw, calc(100vh - var(--cover-controls-budget) - 2.5rem)));
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 2rem;
+  /* 关闭手柄绝对定位在封面上方出画区，这里预留其高度，
+     避免矮窗口下被居中布局顶出视口 */
+  padding-top: 2.5rem;
 
   @media screen and (max-height: 768px) {
-    --cover-size: min(45vh, 38vw);
+    --cover-size: max(9rem, min(45vh, 38vw, calc(100vh - var(--cover-controls-budget) - 2rem)));
     gap: 1.5rem;
+    padding-top: 2.25rem;
   }
 
   .cover-stage {
     position: relative;
-    width: var(--cover-size);
-    height: var(--cover-size);
+    /* 同时受容器实际宽度约束（.left 为 40% 宽减内边距，38vw 在窄局部会超宽） */
+    width: min(var(--cover-size), 100%);
+    aspect-ratio: 1 / 1;
   }
 
   .amll-close-action {
@@ -434,7 +442,9 @@ onMounted(() => {
     }
   }
   .controls {
-    width: var(--cover-size);
+    width: min(var(--cover-size), 100%);
+    /* 封面被矮窗口压得很小时，控件区保底宽度，避免按钮/时间挤作一团 */
+    min-width: min(18rem, 100%);
     display: flex;
     flex-direction: column;
     gap: 1.25rem;
@@ -462,11 +472,11 @@ onMounted(() => {
         flex-direction: column;
         gap: 0.25rem;
         .name {
-          font-size: 1.5rem;
+          font-size: clamp(1.15rem, calc(var(--cover-size) * 0.055), 1.5rem);
           font-weight: 600;
         }
         .artists {
-          font-size: 1rem;
+          font-size: clamp(0.85rem, calc(var(--cover-size) * 0.04), 1rem);
           opacity: 1;
           .artist-name {
             cursor: pointer;

--- a/src/components/Player/PlayerRecord.vue
+++ b/src/components/Player/PlayerRecord.vue
@@ -335,7 +335,7 @@ const closeBigPlayer = () => {
       transform: rotate(-20deg);
       transform-origin: calc(var(--cover-size) * 0.045) calc(var(--cover-size) * 0.045);
       z-index: 1;
-      transition: all 0.3s;
+      transition: all var(--duration-300) var(--ease-out);
       &.play {
         transform: rotate(0);
       }
@@ -466,13 +466,13 @@ const closeBigPlayer = () => {
           font-size: 1.75rem;
           cursor: pointer;
           opacity: 1;
-          transition: opacity 0.2s ease;
+          transition: opacity var(--duration-200) var(--ease-out);
         }
         .more-button {
           font-size: 1.75rem;
           cursor: pointer;
           opacity: 1;
-          transition: opacity 0.2s ease;
+          transition: opacity var(--duration-200) var(--ease-out);
           &:hover {
             opacity: 1;
           }
@@ -527,8 +527,8 @@ const closeBigPlayer = () => {
         opacity: 1;
         cursor: pointer;
         transition:
-          opacity 0.2s ease,
-          transform 0.1s ease-out;
+          opacity var(--duration-200) var(--ease-out),
+          transform var(--duration-150) var(--ease-out);
         &:hover {
           opacity: 1;
         }

--- a/src/components/Player/PlayerRecord.vue
+++ b/src/components/Player/PlayerRecord.vue
@@ -294,16 +294,29 @@ const closeBigPlayer = () => {
 
 <style lang="scss" scoped>
 .record {
-  --cover-size: min(50vh, 38vw);
+  /* 高度预算：控件区约 15rem + 纵向 gap 2rem + 顶部关闭手柄余量 2.5rem；
+     stage 高为封面的 1.25 倍，故预算需除以 1.25 */
+  --cover-controls-budget: 19.5rem;
+  --cover-size: max(
+    10rem,
+    min(50vh, 38vw, calc((100vh - var(--cover-controls-budget) - 2.5rem) / 1.25))
+  );
   position: relative;
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 2rem;
+  /* 为绝对定位的关闭手柄保留出画余量，避免矮窗口下被居中布局顶出视口 */
+  padding-top: 2.5rem;
 
   @media screen and (max-height: 768px) {
-    --cover-size: min(45vh, 38vw);
+    --cover-size: max(
+      9rem,
+      min(45vh, 38vw, calc((100vh - var(--cover-controls-budget) - 2rem) / 1.25))
+    );
     gap: 1.5rem;
+    padding-top: 2.25rem;
   }
   &:hover {
     .control {
@@ -312,10 +325,33 @@ const closeBigPlayer = () => {
   }
   .record-stage {
     position: relative;
-    width: var(--cover-size);
-    height: calc(var(--cover-size) * 1.25);
+    width: min(var(--cover-size), 100%);
+    aspect-ratio: 4 / 5;
     display: grid;
     place-items: end center;
+
+    /* 盘面高光：固定光源，不随唱片旋转（旋转动画在 .pic 上） */
+    &::after {
+      content: "";
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      width: min(var(--cover-size), 100%);
+      aspect-ratio: 1 / 1;
+      border-radius: 50%;
+      background: conic-gradient(
+        from 210deg,
+        transparent 0deg,
+        rgb(255 255 255 / 0.07) 42deg,
+        transparent 95deg,
+        transparent 185deg,
+        rgb(255 255 255 / 0.04) 235deg,
+        transparent 285deg
+      );
+      pointer-events: none;
+      z-index: 1;
+    }
 
     .amll-close-action {
       position: absolute;
@@ -334,84 +370,63 @@ const closeBigPlayer = () => {
       top: calc(var(--cover-size) * 0.02);
       transform: rotate(-20deg);
       transform-origin: calc(var(--cover-size) * 0.045) calc(var(--cover-size) * 0.045);
-      z-index: 1;
-      transition: all var(--duration-300) var(--ease-out);
+      z-index: 2;
+      filter: drop-shadow(0 6px 10px rgb(0 0 0 / 0.3));
+      transition: transform var(--duration-400) var(--ease-out);
       &.play {
         transform: rotate(0);
       }
     }
     .pic {
+      position: relative;
       animation: rotate 18s linear infinite;
       border-radius: 50%;
-      border: calc(var(--cover-size) * 0.025) solid #ffffff30;
-      background:
-        linear-gradient(black 0%, transparent, black 98%),
-        radial-gradient(
-          #000 52%,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555,
-          #000,
-          #555
-        );
-      background-clip: content-box;
-      width: var(--cover-size);
-      height: var(--cover-size);
+      width: min(var(--cover-size), 100%);
+      height: auto;
+      aspect-ratio: 1 / 1;
       display: flex;
       justify-content: center;
       align-items: center;
-      .album {
-        border: calc(var(--cover-size) * 0.025) solid #ffffff40;
+      /* 黑胶盘面：细密沟槽 + 低对比中心过渡，替代原先的粗黑灰环 */
+      background:
+        radial-gradient(circle at center, rgb(255 255 255 / 0.05) 0%, transparent 60%),
+        repeating-radial-gradient(
+          circle at center,
+          #0b0b0d 0,
+          #0b0b0d 2.5px,
+          #191a1d 3px,
+          #0b0b0d 3.5px
+        ),
+        #0b0b0d;
+      box-shadow:
+        0 20px 46px rgb(0 0 0 / 0.38),
+        inset 0 0 0 1px rgb(255 255 255 / 0.12),
+        inset 0 0 calc(var(--cover-size) * 0.12) rgb(0 0 0 / 0.55);
+
+      /* 中心轴点 */
+      &::after {
+        content: "";
+        position: absolute;
+        width: calc(var(--cover-size) * 0.02);
+        height: calc(var(--cover-size) * 0.02);
         border-radius: 50%;
-        width: 64%;
-        height: 64%;
+        background: #e6e6e6;
+        box-shadow:
+          0 0 0 2px rgb(0 0 0 / 0.65),
+          0 1px 3px rgb(0 0 0 / 0.5);
+        z-index: 2;
+      }
+
+      .album {
+        border-radius: 50%;
+        width: 62%;
+        height: 62%;
         object-fit: cover;
+        border: 1px solid rgb(255 255 255 / 0.16);
+        /* 标签与盘面间的过渡圈 */
+        box-shadow:
+          0 0 0 calc(var(--cover-size) * 0.012) rgb(0 0 0 / 0.42),
+          0 0 calc(var(--cover-size) * 0.05) rgb(0 0 0 / 0.3);
       }
     }
   }

--- a/src/components/Player/RollingLyrics.vue
+++ b/src/components/Player/RollingLyrics.vue
@@ -50,8 +50,8 @@ const lyricClasses = computed(() => ({
   transform: translateZ(0) scale(1);
   will-change: transform, opacity;
   transition:
-    transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
-    opacity 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+    transform var(--duration-500) cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity var(--duration-500) cubic-bezier(0.34, 1.56, 0.64, 1);
 
   @media (max-width: 768px) {
     height: 100%;

--- a/src/components/Player/Spectrum.vue
+++ b/src/components/Player/Spectrum.vue
@@ -193,7 +193,7 @@ onBeforeUnmount(() => {
   justify-content: center;
   opacity: 0.6;
   pointer-events: none;
-  transition: opacity 0.3s;
+  transition: opacity var(--duration-300) var(--ease-out);
   mask: linear-gradient(
     90deg,
     hsla(0, 0%, 100%, 0) 0,

--- a/src/components/Player/index.vue
+++ b/src/components/Player/index.vue
@@ -1086,7 +1086,7 @@ watch(
 .show-enter-active,
 .show-leave-active {
   transform: translateY(0);
-  transition: all 0.3s cubic-bezier(0.65, 0.05, 0.36, 1);
+  transition: all var(--duration-300) cubic-bezier(0.65, 0.05, 0.36, 1);
 }
 
 .show-enter-from,
@@ -1096,7 +1096,7 @@ watch(
 
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: opacity var(--duration-150) var(--ease-in-out);
 }
 
 .mini-lyric-enter-active,
@@ -1332,7 +1332,7 @@ watch(
           font-size: 16px;
           font-weight: bold;
           cursor: pointer;
-          transition: all 0.3s;
+          transition: all var(--duration-300) var(--ease-out);
 
           &:hover {
             color: var(--player-accent-color);
@@ -1419,7 +1419,7 @@ watch(
         padding: 4px;
         border-radius: var(--radius-pill);
         transform: scale(1);
-        transition: all 0.3s;
+        transition: all var(--duration-300) var(--ease-out);
 
         &:hover {
           color: var(--n-color-embedded);
@@ -1442,7 +1442,7 @@ watch(
         margin: 0 12px;
         cursor: pointer;
         transform: scale(1);
-        transition: all 0.3s;
+        transition: all var(--duration-300) var(--ease-out);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -1500,7 +1500,7 @@ watch(
         padding: 4px;
         border-radius: var(--radius-md);
         cursor: pointer;
-        transition: all 0.3s;
+        transition: all var(--duration-300) var(--ease-out);
 
         @media (min-width: 640px) {
           &:hover {

--- a/src/components/QueuePanel/index.vue
+++ b/src/components/QueuePanel/index.vue
@@ -34,6 +34,7 @@
       </div>
       <n-virtual-list
         v-if="music.getPlaylists.length"
+        ref="virtualListRef"
         class="queue-scroll"
         :items="queueRows"
         :item-size="49"
@@ -99,6 +100,8 @@ import AllArtists from "@/components/DataList/AllArtists.vue";
 
 const music = musicStore();
 
+const virtualListRef = ref(null);
+
 const currentSong = computed(() => music.getPlaySongData);
 const queueRows = computed(() =>
   music.getPlaylists.map((item, index) => ({
@@ -111,6 +114,16 @@ const queueRows = computed(() =>
 const changeIndex = (index) => {
   music.selectPlaySongByIndex(index);
 };
+
+// 滚动到当前播放曲目（供抽屉等容器在打开时调用）
+const scrollToCurrent = () => {
+  const index = music.persistData.playSongIndex;
+  if (index >= 0 && index < music.getPlaylists.length) {
+    virtualListRef.value?.scrollTo({ index });
+  }
+};
+
+defineExpose({ scrollToCurrent });
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/SearchInp/index.vue
+++ b/src/components/SearchInp/index.vue
@@ -446,9 +446,9 @@ watch(
       0 8px 24px rgb(0 0 0 / 8%),
       inset 0 0 0 1px var(--acrylic-border, rgba(255, 255, 255, 0.16));
     transition:
-      width 0.3s,
-      background-color 0.2s,
-      box-shadow 0.2s;
+      width var(--duration-300) var(--ease-out),
+      background-color var(--duration-200) var(--ease-out),
+      box-shadow var(--duration-200) var(--ease-out);
 
     @media (max-width: 450px) {
       width: 36px;
@@ -515,7 +515,7 @@ watch(
 
     :deep(.n-input__prefix) {
       .n-icon {
-        transition: color 0.3s;
+        transition: color var(--duration-300) var(--ease-out);
         &.active {
           color: var(--main-color);
         }
@@ -620,7 +620,7 @@ watch(
                 color: var(--search-chip-text);
                 font-size: 12px;
                 cursor: pointer;
-                transition: all 0.3s;
+                transition: all var(--duration-300) var(--ease-out);
                 &:hover {
                   background-color: var(--search-chip-bg-hover);
                   box-shadow:
@@ -654,7 +654,7 @@ watch(
               cursor: pointer;
               border-radius: var(--radius-md);
               padding: 5px;
-              transition: all 0.3s;
+              transition: all var(--duration-300) var(--ease-out);
 
               &:nth-last-of-type(1) {
                 margin-bottom: 0;
@@ -748,7 +748,7 @@ watch(
                 padding: 10px 12px 10px 16px;
                 font-size: 13px;
                 cursor: pointer;
-                transition: all 0.3s;
+                transition: all var(--duration-300) var(--ease-out);
                 border-radius: var(--radius-md);
                 &:hover {
                   background-color: var(--n-border-color);

--- a/src/components/Settings/SettingsAppUpdate.vue
+++ b/src/components/Settings/SettingsAppUpdate.vue
@@ -441,7 +441,7 @@ const handleInstallUpdate = () => {
     .release-notes-body {
       max-height: 320px;
       border: 1px solid color-mix(in srgb, var(--n-border-color) 70%, transparent);
-      border-radius: 6px;
+      border-radius: var(--radius-sm);
       overflow: hidden;
 
       :deep(.release-notes-markdown) {

--- a/src/components/Settings/SettingsPanel.vue
+++ b/src/components/Settings/SettingsPanel.vue
@@ -277,7 +277,7 @@ watch(
     &::-webkit-scrollbar-thumb {
       min-height: 28px;
       border: 2px solid transparent;
-      border-radius: 999px;
+      border-radius: var(--radius-pill);
       background-clip: content-box;
       background-color: transparent;
     }
@@ -374,7 +374,7 @@ watch(
         min-width: 20px;
         height: 19px;
         padding: 0 6px;
-        border-radius: 999px;
+        border-radius: var(--radius-pill);
         background-color: color-mix(in srgb, var(--n-text-color) 8%, transparent);
         font-size: 11px;
         font-variant-numeric: tabular-nums;

--- a/src/components/Settings/SettingsWorkspace.vue
+++ b/src/components/Settings/SettingsWorkspace.vue
@@ -445,7 +445,7 @@ const handleAction = (key: string) => {
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     background-color: var(--color, var(--main-color));
     cursor: pointer;
     overflow: hidden;
@@ -458,7 +458,7 @@ const handleAction = (key: string) => {
       position: absolute;
       inset: 4px;
       border: 2px solid rgb(255 255 255 / 0.72);
-      border-radius: 6px;
+      border-radius: var(--radius-sm);
       opacity: 0;
       transition: opacity var(--duration-150) var(--ease-out);
     }

--- a/src/components/Sidebar/MobileTabBar.vue
+++ b/src/components/Sidebar/MobileTabBar.vue
@@ -60,7 +60,7 @@ const isActive = (tab) => {
   align-items: center;
   pointer-events: var(--mobile-mini-player-bottom-pointer-events, auto);
   transform: translate3d(0, var(--mobile-mini-player-bottom-y, 0%), 0);
-  transition: background-color 0.3s;
+  transition: background-color var(--duration-300) var(--ease-out);
   will-change: transform;
 
   &.dark {
@@ -83,7 +83,7 @@ const isActive = (tab) => {
   height: 100%;
   cursor: pointer;
   color: #999;
-  transition: color 0.3s;
+  transition: color var(--duration-300) var(--ease-out);
 
   .dark & {
     color: #777;

--- a/src/components/Sidebar/SidebarPlaylistItem.vue
+++ b/src/components/Sidebar/SidebarPlaylistItem.vue
@@ -44,7 +44,7 @@ defineEmits(["navigate"]);
   padding: 0;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color var(--duration-200) var(--ease-out);
   overflow: hidden;
   white-space: nowrap;
 
@@ -76,7 +76,7 @@ defineEmits(["navigate"]);
   min-width: 22px;
   border-radius: var(--radius-sm);
   object-fit: cover;
-  transition: border-radius 0.2s;
+  transition: border-radius var(--duration-200) var(--ease-out);
 
   .collapsed & {
     border-radius: var(--radius-pill);

--- a/src/components/Sidebar/index.vue
+++ b/src/components/Sidebar/index.vue
@@ -568,7 +568,7 @@ const goToPlaylist = (id: number) => {
   display: flex;
   flex-direction: column;
   background-color: var(--app-shell-bg, var(--layout-bg, #fff));
-  transition: background-color 0.3s;
+  transition: background-color var(--duration-300) var(--ease-out);
   overflow: hidden;
   overscroll-behavior: contain;
   contain: layout paint;
@@ -627,7 +627,7 @@ const goToPlaylist = (id: number) => {
   padding: 8px 12px;
   min-height: 46px;
   background-color: var(--app-shell-bg, var(--layout-bg, #fff));
-  transition: padding 0.22s ease-in-out;
+  transition: padding var(--duration-200) var(--ease-in-out);
 
   &::after {
     content: "";
@@ -643,14 +643,14 @@ const goToPlaylist = (id: number) => {
       rgba(var(--app-shell-rgb, 242, 242, 244), 0.72),
       rgba(var(--app-shell-rgb, 242, 242, 244), 0)
     );
-    transition: opacity 0.18s ease;
+    transition: opacity var(--duration-200) var(--ease-out);
   }
 }
 
 .sidebar-search {
   min-width: 0;
   opacity: 1;
-  transition: opacity 0.15s ease;
+  transition: opacity var(--duration-150) var(--ease-out);
 
   :deep(.list) {
     z-index: var(--z-search-overlay, 1900);
@@ -813,7 +813,7 @@ const goToPlaylist = (id: number) => {
   padding: 1px 8px;
   max-width: 100%;
   box-sizing: border-box;
-  transition: padding 0.3s ease;
+  transition: padding var(--duration-300) var(--ease-out);
 
   &.collapsed {
     padding: 1px 8px;
@@ -853,7 +853,7 @@ const goToPlaylist = (id: number) => {
 
   span {
     opacity: 1;
-    transition: opacity 0.18s ease;
+    transition: opacity var(--duration-200) var(--ease-out);
   }
 
   .section-chevron {
@@ -928,7 +928,7 @@ const goToPlaylist = (id: number) => {
   padding: 7px 8px;
   border-top: 1px solid var(--sidebar-divider);
   background-color: var(--app-shell-bg, var(--layout-bg, #fff));
-  transition: padding 0.22s ease-in-out;
+  transition: padding var(--duration-200) var(--ease-in-out);
 
   &::before {
     content: "";
@@ -944,7 +944,7 @@ const goToPlaylist = (id: number) => {
       rgba(var(--app-shell-rgb, 242, 242, 244), 0.78),
       rgba(var(--app-shell-rgb, 242, 242, 244), 0)
     );
-    transition: opacity 0.18s ease;
+    transition: opacity var(--duration-200) var(--ease-out);
   }
 }
 
@@ -959,7 +959,7 @@ const goToPlaylist = (id: number) => {
   border-radius: var(--radius-md);
   background-color: var(--sidebar-hover-bg);
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color var(--duration-200) var(--ease-out);
   overflow: hidden;
   white-space: nowrap;
 
@@ -1001,11 +1001,11 @@ const goToPlaylist = (id: number) => {
 
 // Text fade transition for section titles
 .sidebar-text-fade-enter-active {
-  transition: opacity 0.25s ease 0.15s;
+  transition: opacity var(--duration-200) var(--ease-out) 0.15s;
 }
 
 .sidebar-text-fade-leave-active {
-  transition: opacity 0.1s ease;
+  transition: opacity var(--duration-150) var(--ease-out);
 }
 
 .sidebar-text-fade-enter-from,

--- a/src/components/TitleBar/WindowControls.vue
+++ b/src/components/TitleBar/WindowControls.vue
@@ -154,8 +154,8 @@ onBeforeUnmount(() => {
   color: inherit;
   background-color: transparent;
   transition:
-    background-color 0.12s ease,
-    color 0.12s ease;
+    background-color var(--duration-150) var(--ease-out),
+    color var(--duration-150) var(--ease-out);
 
   &:hover {
     background-color: color-mix(in srgb, currentColor 12%, transparent);

--- a/src/components/TitleBar/index.vue
+++ b/src/components/TitleBar/index.vue
@@ -90,9 +90,9 @@ onMounted(async () => {
   -webkit-app-region: no-drag;
   app-region: no-drag;
   transition:
-    opacity 0.25s ease,
-    background-color 0.2s ease,
-    border-color 0.2s ease;
+    opacity var(--duration-200) var(--ease-out),
+    background-color var(--duration-200) var(--ease-out),
+    border-color var(--duration-200) var(--ease-out);
 
   &.dark-mode {
     --titlebar-bg: rgba(24, 24, 24, 0.56);

--- a/src/components/TitleBar/index.vue
+++ b/src/components/TitleBar/index.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, type Component } from "vue";
+import { ref, computed, onMounted, onBeforeUnmount, type Component } from "vue";
 import { musicStore, settingStore } from "@/store";
 import { isTauri } from "@/utils/tauri/windowManager";
 import { getDesktopEnvironment, isMobile, type DesktopEnvironment } from "@/utils/tauri";
@@ -77,6 +77,18 @@ onMounted(async () => {
   if (usesNativeTrafficLights.value && !props.showOnMac) return;
 
   showTitleBar.value = true;
+
+  // 悬浮窗口控制按钮占用右上角，通知 body 级浮层（右侧抽屉、通知）让位。
+  // 抽屉/通知 teleport 到 body，取不到 .app-body 上的环境类，因此挂在 <html> 上。
+  if (props.variant === "floating") {
+    document.documentElement.classList.add("has-floating-titlebar");
+  }
+});
+
+onBeforeUnmount(() => {
+  if (showTitleBar.value && props.variant === "floating") {
+    document.documentElement.classList.remove("has-floating-titlebar");
+  }
 });
 </script>
 
@@ -105,7 +117,7 @@ onMounted(async () => {
   top: var(--app-floating-control-top);
   right: var(--app-floating-control-inset, 14px);
   z-index: 9999;
-  height: 30px;
+  height: var(--app-titlebar-height, 30px);
   border: 1px solid var(--acrylic-border, rgba(0, 0, 0, 0.06));
   border-radius: var(--radius-lg);
   background-color: var(--titlebar-bg, rgba(255, 255, 255, 0.52));

--- a/src/style/global.scss
+++ b/src/style/global.scss
@@ -32,6 +32,13 @@
   --shadow-3: 0 8px 24px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.08);
   --shadow-hover: 0 12px 30px rgba(0, 0, 0, 0.14), 0 3px 8px rgba(0, 0, 0, 0.09);
 
+  /* Semantic surface tokens — shadcn/ui 式语义变量（浅色默认值，深色见 html[data-theme="dark"]） */
+  --border-color: rgba(0, 0, 0, 0.08);
+  --border-strong: rgba(0, 0, 0, 0.14);
+  --hover-overlay: rgba(0, 0, 0, 0.05);
+  --active-overlay: rgba(0, 0, 0, 0.09);
+  --focus-ring: 0 0 0 3px color-mix(in srgb, var(--main-color, #f55e55) 24%, transparent);
+
   /* Blur — 统一毛玻璃模糊强度 */
   --blur-sm: 8px;
   --blur-md: 16px;
@@ -67,6 +74,18 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
+}
+
+/* 深色模式语义 token — 边框/蒙层换白色基调，阴影加深保证层级仍可读 */
+html[data-theme="dark"] {
+  --border-color: rgba(255, 255, 255, 0.1);
+  --border-strong: rgba(255, 255, 255, 0.16);
+  --hover-overlay: rgba(255, 255, 255, 0.07);
+  --active-overlay: rgba(255, 255, 255, 0.12);
+  --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.25), 0 1px 3px rgba(0, 0, 0, 0.22);
+  --shadow-2: 0 2px 8px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.26);
+  --shadow-3: 0 8px 24px rgba(0, 0, 0, 0.42), 0 2px 6px rgba(0, 0, 0, 0.3);
+  --shadow-hover: 0 12px 30px rgba(0, 0, 0, 0.46), 0 3px 8px rgba(0, 0, 0, 0.32);
 }
 
 // HarmonyOS Sans
@@ -274,10 +293,8 @@ body,
     padding: 10px 14px;
     font-size: 13px;
     background: var(--message-bg, rgba(255, 255, 255, 0.72)) !important;
-    border: 1px solid var(--message-border, rgba(0, 0, 0, 0.06));
-    box-shadow:
-      0 4px 12px rgba(0, 0, 0, 0.08),
-      0 1px 3px rgba(0, 0, 0, 0.06);
+    border: 1px solid var(--message-border, var(--border-color));
+    box-shadow: var(--shadow-2);
     -webkit-backdrop-filter: blur(12px) saturate(180%);
     backdrop-filter: blur(12px) saturate(180%);
     transition:
@@ -334,9 +351,7 @@ body,
 // Notification
 .n-notification {
   border-radius: var(--radius-panel) !important;
-  box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.12),
-    0 2px 8px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-3);
 }
 
 // 桌面端通知位置微调

--- a/src/style/global.scss
+++ b/src/style/global.scss
@@ -60,7 +60,10 @@
   --app-floating-control-inset: calc(var(--app-shell-side-gap) + 6px);
   --app-drag-region-height: 42px;
   --app-titlebar-width: 114px;
+  --app-titlebar-height: 30px;
   --app-titlebar-gap: 10px;
+  /* 悬浮 TitleBar 下方的安全距离：右上角浮层（右侧抽屉头部、通知）让位用 */
+  --app-titlebar-safe-top: calc(var(--app-floating-control-top) + var(--app-titlebar-height));
   --z-search-overlay: 2200;
 
   /* Precomposed shortcuts */
@@ -358,6 +361,18 @@ body,
 .n-notification-container--top-right {
   top: 16px !important;
   right: 16px !important;
+}
+
+// Tauri 悬浮窗口控制按钮占用右上角时，右上角的 body 级浮层需要让位
+// （类由 TitleBar 悬浮变体挂载时打在 <html> 上）
+html.has-floating-titlebar {
+  .n-notification-container--top-right {
+    top: calc(var(--app-titlebar-safe-top, 42px) + 10px) !important;
+  }
+
+  .n-drawer--right-placement .n-drawer-header {
+    margin-top: var(--app-titlebar-safe-top, 42px);
+  }
 }
 
 // Nalert

--- a/src/views/Album/AlbumView.vue
+++ b/src/views/Album/AlbumView.vue
@@ -345,7 +345,7 @@ watch(
       width: 100%;
       aspect-ratio: 1 / 1;
       border-radius: var(--radius-md);
-      transition: transform 0.3s;
+      transition: transform var(--duration-300) var(--ease-out);
       filter: drop-shadow(0 16px 28px rgba(var(--content-panel-accent-rgb, 0, 0, 0), 0.22));
 
       &:active {
@@ -421,7 +421,7 @@ watch(
           font-weight: 700;
           color: var(--n-text-color-2);
           cursor: pointer;
-          transition: color 0.2s;
+          transition: color var(--duration-200) var(--ease-out);
 
           &:hover {
             color: rgb(var(--content-panel-accent-rgb, 128, 128, 128));
@@ -481,7 +481,7 @@ watch(
           color: var(--n-text-color-2);
           background-color: color-mix(in srgb, var(--n-border-color) 62%, transparent);
           cursor: pointer;
-          transition: all 0.3s;
+          transition: all var(--duration-300) var(--ease-out);
 
           &:hover {
             background-color: color-mix(

--- a/src/views/Artist/index.vue
+++ b/src/views/Artist/index.vue
@@ -330,7 +330,7 @@ watch(
       width: 100%;
       aspect-ratio: 1 / 1;
       border-radius: var(--radius-md);
-      transition: transform 0.3s;
+      transition: transform var(--duration-300) var(--ease-out);
       filter: drop-shadow(0 16px 28px rgba(var(--content-panel-accent-rgb, 0, 0, 0), 0.22));
 
       &:active {

--- a/src/views/Artist/songs.vue
+++ b/src/views/Artist/songs.vue
@@ -220,7 +220,7 @@ watch(
   .latest-cover {
     width: 100%;
     aspect-ratio: 1;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     object-fit: cover;
     box-shadow: 0 14px 28px rgb(0 0 0 / 12%);
   }
@@ -282,7 +282,7 @@ watch(
   .rank-cover {
     width: 44px;
     height: 44px;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     object-fit: cover;
   }
 
@@ -313,7 +313,7 @@ watch(
     margin-top: 40px;
     width: 140px;
     font-size: 16px;
-    transition: all 0.3s;
+    transition: all var(--duration-300) var(--ease-out);
 
     &:hover {
       background-color: var(--main-second-color);

--- a/src/views/Comment/CommentView.vue
+++ b/src/views/Comment/CommentView.vue
@@ -145,7 +145,7 @@ watch(
 .comment {
   .up-enter-active,
   .up-leave-active {
-    transition: all 0.3s ease;
+    transition: all var(--duration-300) var(--ease-out);
   }
 
   .up-enter-from,
@@ -163,7 +163,7 @@ watch(
       background-color: var(--n-border-color);
     }
     :deep(.n-card__content) {
-      transition: all 0.3s;
+      transition: all var(--duration-300) var(--ease-out);
       font-size: 12px;
     }
   }
@@ -177,7 +177,7 @@ watch(
     }
     .song {
       margin-top: 20px;
-      border-radius: 8px;
+      border-radius: var(--radius-md);
     }
   }
   .hotComments,

--- a/src/views/Discover/artists.vue
+++ b/src/views/Discover/artists.vue
@@ -236,7 +236,7 @@ onMounted(() => {
       padding: 0 16px;
       line-height: 0;
       cursor: pointer;
-      transition: all 0.3s;
+      transition: all var(--duration-300) var(--ease-out);
 
       &:hover {
         background-color: var(--main-second-color);
@@ -263,7 +263,7 @@ onMounted(() => {
     margin-top: 40px;
     width: 140px;
     font-size: 16px;
-    transition: all 0.3s;
+    transition: all var(--duration-300) var(--ease-out);
 
     &:hover {
       background-color: var(--main-second-color);

--- a/src/views/Discover/playlists.vue
+++ b/src/views/Discover/playlists.vue
@@ -311,7 +311,7 @@ onMounted(() => {
     margin-top: 40px;
     width: 140px;
     font-size: 16px;
-    transition: all 0.3s;
+    transition: all var(--duration-300) var(--ease-out);
     &:hover {
       background-color: var(--main-second-color);
       color: var(--main-color);
@@ -336,7 +336,7 @@ onMounted(() => {
 }
 .tag {
   cursor: pointer;
-  transition: all 0.3s;
+  transition: all var(--duration-300) var(--ease-out);
   &:hover {
     background-color: var(--main-second-color);
     color: var(--main-color);

--- a/src/views/Discover/toplists.vue
+++ b/src/views/Discover/toplists.vue
@@ -98,7 +98,7 @@ onMounted(() => {
 .toplists {
   .v-enter-active,
   .v-leave-active {
-    transition: opacity 0.3s ease;
+    transition: opacity var(--duration-300) var(--ease-out);
   }
 
   .v-enter-from,
@@ -124,8 +124,8 @@ onMounted(() => {
       }
     }
     .item {
-      border-radius: 8px;
-      transition: all 0.3s;
+      border-radius: var(--radius-md);
+      transition: all var(--duration-300) var(--ease-out);
       overflow: hidden;
       cursor: pointer;
       &:active {
@@ -141,7 +141,7 @@ onMounted(() => {
           width: 160px;
           height: 160px;
           min-width: 160px;
-          border-radius: 8px;
+          border-radius: var(--radius-md);
         }
         .update {
           position: absolute;
@@ -153,7 +153,7 @@ onMounted(() => {
           -webkit-backdrop-filter: blur(40px);
           backdrop-filter: blur(40px);
           padding: 4px 8px;
-          border-radius: 8px 0 8px 0;
+          border-radius: var(--radius-md) 0 var(--radius-md) 0;
         }
       }
       .data {

--- a/src/views/Home/HomeView.vue
+++ b/src/views/Home/HomeView.vue
@@ -768,7 +768,7 @@ onBeforeUnmount(() => {
     width: 44px;
     height: 44px;
     object-fit: cover;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
   }
 
   &:hover,

--- a/src/views/Login/LoginView.vue
+++ b/src/views/Login/LoginView.vue
@@ -368,14 +368,14 @@ onBeforeUnmount(() => {
     .qr-img {
       width: 220px;
       height: 220px;
-      border-radius: 8px;
+      border-radius: var(--radius-md);
       background-color: #fff;
       :deep(.n-card__content) {
         display: flex;
         align-items: center;
         justify-content: center;
         .n-skeleton {
-          border-radius: 8px;
+          border-radius: var(--radius-md);
         }
       }
     }

--- a/src/views/MiniPlayer/index.vue
+++ b/src/views/MiniPlayer/index.vue
@@ -517,7 +517,7 @@ onUnmounted(() => {
   height: 100%;
   overflow: hidden;
   z-index: -2;
-  transition: filter 0.5s ease;
+  transition: filter var(--duration-500) var(--ease-out);
   will-change: filter, opacity;
 }
 
@@ -568,8 +568,8 @@ onUnmounted(() => {
     border: none;
     color: rgba(255, 255, 255, 0.4);
     cursor: pointer;
-    border-radius: 6px;
-    transition: all 0.15s ease;
+    border-radius: var(--radius-sm);
+    transition: all var(--duration-150) var(--ease-out);
 
     &:hover {
       background: rgba(255, 255, 255, 0.1);
@@ -605,7 +605,7 @@ onUnmounted(() => {
   .cover {
     width: 52px;
     height: 52px;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     object-fit: cover;
     flex-shrink: 0;
     background: rgba(255, 255, 255, 0.05);
@@ -673,7 +673,7 @@ onUnmounted(() => {
   cursor: pointer;
   padding: 6px;
   border-radius: 50%;
-  transition: all 0.15s ease;
+  transition: all var(--duration-150) var(--ease-out);
 
   &:hover {
     background: rgba(255, 255, 255, 0.1);
@@ -710,7 +710,7 @@ onUnmounted(() => {
 
 .expand-fade-enter-active,
 .expand-fade-leave-active {
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-300) var(--ease-in-out);
 }
 
 .expand-fade-enter-from,
@@ -737,7 +737,7 @@ onUnmounted(() => {
   bottom: 0;
   display: flex;
   flex-direction: column;
-  transition: opacity 0.35s ease;
+  transition: opacity var(--duration-400) var(--ease-out);
 }
 
 .layer-cover {
@@ -784,7 +784,7 @@ onUnmounted(() => {
     cursor: pointer;
     padding: 4px;
     border-radius: 50%;
-    transition: all 0.2s ease;
+    transition: all var(--duration-200) var(--ease-out);
     margin-top: 4px;
 
     &:hover {

--- a/src/views/NewAlbum/NewAlbumView.vue
+++ b/src/views/NewAlbum/NewAlbumView.vue
@@ -166,7 +166,7 @@ onMounted(() => {
       padding: 0 16px;
       line-height: 0;
       cursor: pointer;
-      transition: all 0.3s;
+      transition: all var(--duration-300) var(--ease-out);
       &:hover {
         background-color: var(--main-second-color);
         color: var(--main-color);

--- a/src/views/PlayList/PlayListView.vue
+++ b/src/views/PlayList/PlayListView.vue
@@ -516,7 +516,7 @@ watch(
       width: 100%;
       aspect-ratio: 1 / 1;
       border-radius: var(--radius-md);
-      transition: transform 0.3s;
+      transition: transform var(--duration-300) var(--ease-out);
       filter: drop-shadow(0 16px 28px rgba(var(--content-panel-accent-rgb, 0, 0, 0), 0.22));
 
       &:active {
@@ -649,7 +649,7 @@ watch(
           color: var(--n-text-color-2);
           background-color: color-mix(in srgb, var(--n-border-color) 62%, transparent);
           cursor: pointer;
-          transition: all 0.3s;
+          transition: all var(--duration-300) var(--ease-out);
 
           &:hover {
             background-color: color-mix(

--- a/src/views/Song/SongView.vue
+++ b/src/views/Song/SongView.vue
@@ -358,7 +358,7 @@ watch(
       width: 100%;
       aspect-ratio: 1 / 1;
       border-radius: var(--radius-md);
-      transition: transform 0.3s;
+      transition: transform var(--duration-300) var(--ease-out);
       filter: drop-shadow(0 16px 28px rgba(var(--content-panel-accent-rgb, 0, 0, 0), 0.22));
 
       &:active {
@@ -506,7 +506,7 @@ watch(
           font-size: 12px;
           color: var(--n-text-color-2);
           background-color: color-mix(in srgb, var(--n-border-color) 62%, transparent);
-          transition: all 0.3s;
+          transition: all var(--duration-300) var(--ease-out);
 
           &:hover {
             background-color: color-mix(

--- a/src/views/TrayPopup/index.vue
+++ b/src/views/TrayPopup/index.vue
@@ -467,7 +467,7 @@ function preventRefresh(event: KeyboardEvent) {
   background: transparent;
   color: inherit;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--duration-150) var(--ease-out);
 
   &:hover {
     background: var(--hover-bg);
@@ -481,7 +481,7 @@ function preventRefresh(event: KeyboardEvent) {
 .cover {
   width: 36px;
   height: 36px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   object-fit: cover;
   flex-shrink: 0;
   background: var(--cover-bg);
@@ -541,7 +541,7 @@ function preventRefresh(event: KeyboardEvent) {
   cursor: pointer;
   padding: 6px;
   border-radius: 50%;
-  transition: all 0.15s ease;
+  transition: all var(--duration-150) var(--ease-out);
 
   &:hover {
     background: var(--ctrl-hover-bg);
@@ -610,7 +610,7 @@ function preventRefresh(event: KeyboardEvent) {
   --bouncing-slider-icon-gap: 0;
 
   :deep(.inner) {
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     background-color: var(--slider-track);
   }
 
@@ -643,7 +643,7 @@ function preventRefresh(event: KeyboardEvent) {
   background: transparent;
   color: inherit;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--duration-150) var(--ease-out);
   flex-shrink: 0;
 
   &:hover {

--- a/src/views/Video/VideoView.vue
+++ b/src/views/Video/VideoView.vue
@@ -286,7 +286,7 @@ watch(
   .mainVideo {
     flex: 1;
     :deep(.plyr) {
-      border-radius: 8px;
+      border-radius: var(--radius-md);
       overflow: hidden;
     }
     .info {
@@ -313,7 +313,7 @@ watch(
           flex-direction: row;
           align-items: center;
           cursor: pointer;
-          transition: all 0.3s;
+          transition: all var(--duration-300) var(--ease-out);
           &::after {
             content: "·";
             margin: 0 6px;


### PR DESCRIPTION
- global.scss 新增 --border-color/--hover-overlay/--active-overlay/--focus-ring 语义变量
- 补充深色模式下的边框、蒙层与阴影 token(html[data-theme=dark])
- 消息/通知阴影与边框改用统一 token
- CoverLists/Sidebar/Nav/TitleBar 硬编码圆角、过渡、阴影统一到 token