### PR TITLE
fix(performance): 修复长时间播放导致内存/CPU 持续增长的多处泄漏

### DIFF
--- a/src-tauri/crates/audio-backend/src/automix/mod.rs
+++ b/src-tauri/crates/audio-backend/src/automix/mod.rs
@@ -241,7 +241,16 @@ fn decode_audio_to_mono(audio_data: Vec<u8>) -> Result<(Vec<f32>, u32, f32), Str
     let sample_rate = decoder.sample_rate().get();
     let duration_hint = decoder.total_duration().map(|d| d.as_secs_f32());
 
+    // Pre-size from the duration hint: pushing tens of millions of samples
+    // through doubling reallocs transiently doubles the footprint and leaves
+    // oversized freed segments in the allocator. Cap the reservation so a
+    // bogus hint can't trigger a huge upfront allocation.
     let mut mono = Vec::new();
+    if let Some(secs) = duration_hint.filter(|d| *d > 0.0) {
+        const MAX_RESERVE_SECS: f32 = 900.0;
+        let frames = (secs.min(MAX_RESERVE_SECS) * sample_rate as f32) as usize + 1024;
+        mono.reserve_exact(frames);
+    }
     let mut frame_sum = 0.0f32;
     let mut frame_channel = 0usize;
 

--- a/src-tauri/crates/audio-backend/src/player/api.rs
+++ b/src-tauri/crates/audio-backend/src/player/api.rs
@@ -1,5 +1,5 @@
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::thread;
 
@@ -64,6 +64,11 @@ pub struct PlayerShared {
     pub state: AtomicU8,
     pub position_ms: AtomicU64,
     pub duration_ms: AtomicU64,
+    /// True once a poll consumer has shown up (`audio_poll_events` /
+    /// `audio_set_session`). Until then the forwarder skips the per-event
+    /// clone into `event_buf` — the Channel/emit path is the live consumer and
+    /// buffering for a poller that never arrives is pure waste.
+    pub event_poll_active: AtomicBool,
     pub event_buf: parking_lot::Mutex<EventBuffer>,
     /// Event sink registered by the frontend via `audio_subscribe_events`.
     /// The forwarder streams every `AudioThreadEventMessage` here; when no
@@ -84,6 +89,7 @@ impl Player {
             state: AtomicU8::new(PlaybackState::Stopped as u8),
             position_ms: AtomicU64::new(0),
             duration_ms: AtomicU64::new(0),
+            event_poll_active: AtomicBool::new(false),
             event_buf: parking_lot::Mutex::new(EventBuffer::new(0)),
             event_channel: parking_lot::Mutex::new(None),
         });
@@ -110,7 +116,9 @@ impl Player {
                 if let Some(event) = &evt_msg.data {
                     update_shared_from_event(&shared_clone, event);
                     if should_buffer_poll_event(event) {
-                        shared_clone.event_buf.lock().push(event.clone());
+                        if shared_clone.event_poll_active.load(Ordering::Relaxed) {
+                            shared_clone.event_buf.lock().push(event.clone());
+                        }
                     } else {
                         // High-rate FFT/lowFreq frames: the next frame supersedes
                         // this one anyway, so skip the fallback global emit and
@@ -253,10 +261,12 @@ impl Player {
     }
 
     pub fn poll_events(&self, session_id: u64) -> Vec<AudioThreadEvent> {
+        self.shared.event_poll_active.store(true, Ordering::Relaxed);
         self.shared.event_buf.lock().drain(session_id)
     }
 
     pub fn set_session(&self, session_id: u64) {
+        self.shared.event_poll_active.store(true, Ordering::Relaxed);
         self.shared.event_buf.lock().reset(session_id);
     }
 

--- a/src-tauri/crates/audio-backend/src/player/queue.rs
+++ b/src-tauri/crates/audio-backend/src/player/queue.rs
@@ -99,7 +99,17 @@ impl PlaybackQueue {
             return;
         }
 
-        self.songs.push(song);
+        // Fallthrough (index matches no entry and isn't an append): replace an
+        // existing entry with the same identity instead of appending — this
+        // path runs on every AutoMix crossfade completion, and unconditional
+        // pushes would grow the queue for the whole session whenever the
+        // frontend replaced the prefill window mid-crossfade.
+        let song_id = song.get_id();
+        if let Some(pos) = self.songs.iter().position(|s| s.get_id() == song_id) {
+            self.songs[pos] = song;
+        } else {
+            self.songs.push(song);
+        }
         self.current_index = index;
     }
 
@@ -174,6 +184,23 @@ mod tests {
         queue.set_index(3);
         assert!(queue.prev().is_none());
         assert_eq!(queue.current_index(), 3);
+    }
+
+    #[test]
+    fn replace_or_set_current_does_not_grow_on_repeated_mismatch() {
+        let mut queue = queue_with(vec![local("a", 10), local("b", 11)], true);
+
+        // Index matches no orig_order and is not an append — first call may add.
+        queue.replace_or_set_current(20, local("x", 20));
+        let len_after_first = queue.playlist_cloned().len();
+        assert_eq!(queue.current_index(), 20);
+
+        // Repeated crossfade completions for the same identity must replace,
+        // not append — an unbounded queue otherwise grows for the session.
+        queue.replace_or_set_current(21, local("x", 21));
+        queue.replace_or_set_current(22, local("x", 22));
+        assert_eq!(queue.playlist_cloned().len(), len_after_first);
+        assert_eq!(queue.current_index(), 22);
     }
 
     #[test]

--- a/src-tauri/src/desktop/window/desktop_lyrics/mouse_through.rs
+++ b/src-tauri/src/desktop/window/desktop_lyrics/mouse_through.rs
@@ -10,13 +10,67 @@
 //! The approach is adapted from:
 //! https://github.com/codecnmc/tauri2-transparent-through
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, Runtime};
+
+// ── Global rdev hook singleton ──────────────────────────────────────
+//
+// `rdev::listen` blocks forever and has no shutdown API, so its thread (an
+// OS-level mouse hook) is permanent once started. It MUST therefore be
+// process-wide: spawning one per `start_mouse_through` call would leak a
+// permanent hook thread on every lock toggle, with per-mouse-move CPU cost
+// growing linearly for the rest of the session.
+//
+// The hook publishes the latest cursor position into atomic slots; the
+// stoppable per-session poller threads read from there.
+
+static RDEV_HOOK_STARTED: AtomicBool = AtomicBool::new(false);
+/// Monotonic move counter — lets pollers skip work when the cursor is idle.
+static MOUSE_MOVE_SEQ: AtomicU64 = AtomicU64::new(0);
+static MOUSE_X_BITS: AtomicU64 = AtomicU64::new(0);
+static MOUSE_Y_BITS: AtomicU64 = AtomicU64::new(0);
+
+fn ensure_global_mouse_hook() {
+    if RDEV_HOOK_STARTED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let spawned = thread::Builder::new()
+        .name("mouse-through-hook".into())
+        .spawn(|| {
+            let callback = |event: rdev::Event| {
+                if let rdev::EventType::MouseMove { x, y } = event.event_type {
+                    MOUSE_X_BITS.store(x.to_bits(), Ordering::Relaxed);
+                    MOUSE_Y_BITS.store(y.to_bits(), Ordering::Relaxed);
+                    MOUSE_MOVE_SEQ.fetch_add(1, Ordering::Release);
+                }
+            };
+            if rdev::listen(callback).is_err() {
+                // Hook failed to install (e.g. missing permissions) — allow a
+                // later start to retry instead of wedging the feature.
+                RDEV_HOOK_STARTED.store(false, Ordering::SeqCst);
+            }
+        });
+    if spawned.is_err() {
+        RDEV_HOOK_STARTED.store(false, Ordering::SeqCst);
+    }
+}
+
+fn read_latest_mouse_pos(last_seen_seq: &mut u64) -> Option<(f64, f64)> {
+    let seq = MOUSE_MOVE_SEQ.load(Ordering::Acquire);
+    if seq == 0 || seq == *last_seen_seq {
+        return None;
+    }
+    *last_seen_seq = seq;
+    Some((
+        f64::from_bits(MOUSE_X_BITS.load(Ordering::Relaxed)),
+        f64::from_bits(MOUSE_Y_BITS.load(Ordering::Relaxed)),
+    ))
+}
 
 /// State shared between the mouse worker thread and Tauri commands.
 pub struct MouseThroughState {
@@ -92,29 +146,14 @@ pub fn start_mouse_through<R: Runtime>(
     let app_handle = app.clone();
     let label_owned = label.to_owned();
 
-    // Spawn the rdev listener thread.
-    let rdev_thread = thread::spawn(move || {
-        let (coord_tx, coord_rx) = mpsc::channel::<(f64, f64)>();
-
-        // Inner thread: run rdev listener.
+    // Install (or reuse) the process-wide rdev hook, then spawn the stoppable
+    // poller for this session.
+    ensure_global_mouse_hook();
+    let poller_thread = thread::spawn(move || {
         let rdev_stop = stop_rx;
-        thread::spawn(move || {
-            let tx = coord_tx;
-            let callback = move |event: rdev::Event| {
-                if let rdev::EventType::MouseMove { x, y } = event.event_type {
-                    let _ = tx.send((x, y));
-                }
-            };
-
-            // rdev::listen blocks; we can't easily interrupt it, so we rely on
-            // the outer loop checking the stop channel and the frontend calling
-            // stop. rdev does not expose a graceful shutdown, so we accept that
-            // the thread will linger until the process exits.
-            let _ = rdev::listen(callback);
-        });
-
         let mut last_emit = Instant::now();
         let mut last_state: Option<bool> = None;
+        let mut last_seen_seq = 0u64;
 
         loop {
             // Check stop signal (non-blocking).
@@ -122,15 +161,9 @@ pub fn start_mouse_through<R: Runtime>(
                 break;
             }
 
-            // Drain all pending coordinates and keep the latest.
-            let mut latest: Option<(f64, f64)> = None;
-            while let Ok(pos) = coord_rx.try_recv() {
-                latest = Some(pos);
-            }
-
-            // Throttle to ~60 FPS (16ms).
+            // Throttle to ~60 FPS (16ms); skip entirely while the cursor is idle.
             if last_emit.elapsed() >= Duration::from_millis(16) {
-                if let Some((gx, gy)) = latest {
+                if let Some((gx, gy)) = read_latest_mouse_pos(&mut last_seen_seq) {
                     let inside = is_inside_regions(&app_handle, &label_owned, gx, gy);
 
                     // Only emit when state changes to reduce IPC traffic.
@@ -142,7 +175,7 @@ pub fn start_mouse_through<R: Runtime>(
                 last_emit = Instant::now();
             }
 
-            thread::sleep(Duration::from_millis(1));
+            thread::sleep(Duration::from_millis(4));
         }
     });
 
@@ -154,7 +187,7 @@ pub fn start_mouse_through<R: Runtime>(
     }
 
     // Detach the thread; it will clean itself up when stopped.
-    let _ = rdev_thread;
+    let _ = poller_thread;
 
     Ok(())
 }

--- a/src-tauri/src/desktop/window/manager.rs
+++ b/src-tauri/src/desktop/window/manager.rs
@@ -13,6 +13,17 @@ use tauri_plugin_decorum::WebviewWindowExt;
 static MAIN_SHELL_EFFECT_INITIALIZED: AtomicBool = AtomicBool::new(false);
 static MAIN_SHELL_DARK: AtomicBool = AtomicBool::new(false);
 
+/// Broadcast a managed window's visibility change. The master window uses this
+/// to gate its slave broadcasts (time anchors / lyric payloads / reconcile
+/// polling) on windows that are actually visible — a hidden-but-alive window
+/// otherwise keeps that machinery running for the rest of the session.
+fn emit_window_visibility(app: &AppHandle, label: &str, visible: bool) {
+    let _ = app.emit(
+        "managed-window-visibility",
+        serde_json::json!({ "label": label, "visible": visible }),
+    );
+}
+
 /// Create or focus a window from a `WindowConfig`.
 ///
 /// If `config.single_instance` is true and a window with the same label already
@@ -30,6 +41,9 @@ pub fn create_window(app: &AppHandle, config: &WindowConfig) -> Result<(), Strin
                 existing.unminimize().map_err(|e| e.to_string())?;
             }
             existing.set_focus().map_err(|e| e.to_string())?;
+            // Re-shown without a page load — no slaveReady handshake fires, so
+            // announce visibility for the master's broadcast gating.
+            emit_window_visibility(app, label, true);
             return Ok(());
         }
     }
@@ -294,6 +308,7 @@ pub fn show_window(app: &AppHandle, label: &str) -> Result<(), String> {
     if label == "main" {
         let _ = app.emit("main-window-visibility", true);
     }
+    emit_window_visibility(app, label, true);
     Ok(())
 }
 
@@ -306,6 +321,7 @@ pub fn hide_window(app: &AppHandle, label: &str) -> Result<(), String> {
     if label == "main" {
         let _ = app.emit("main-window-visibility", false);
     }
+    emit_window_visibility(app, label, false);
     Ok(())
 }
 
@@ -338,6 +354,7 @@ pub fn toggle_window(app: &AppHandle, label: &str) -> Result<(), String> {
         if label == "main" {
             let _ = app.emit("main-window-visibility", false);
         }
+        emit_window_visibility(app, label, false);
         Ok(())
     } else {
         window.show().map_err(|e| e.to_string())?;
@@ -350,6 +367,7 @@ pub fn toggle_window(app: &AppHandle, label: &str) -> Result<(), String> {
         if label == "main" {
             let _ = app.emit("main-window-visibility", true);
         }
+        emit_window_visibility(app, label, true);
         Ok(())
     }
 }
@@ -367,6 +385,7 @@ pub fn focus_window(app: &AppHandle, label: &str) -> Result<(), String> {
     if label == "main" {
         let _ = app.emit("main-window-visibility", true);
     }
+    emit_window_visibility(app, label, true);
     Ok(())
 }
 
@@ -416,7 +435,9 @@ pub fn show_window_at_position(app: &AppHandle, label: &str, x: f64, y: f64) -> 
         .set_position(PhysicalPosition::new(x as i32, y as i32))
         .map_err(|e| e.to_string())?;
     window.show().map_err(|e| e.to_string())?;
-    window.set_focus().map_err(|e| e.to_string())
+    window.set_focus().map_err(|e| e.to_string())?;
+    emit_window_visibility(app, label, true);
+    Ok(())
 }
 
 /// Set whether a window ignores cursor events (click-through).

--- a/src/components/DataModal/DownloadSong.vue
+++ b/src/components/DataModal/DownloadSong.vue
@@ -94,6 +94,9 @@ const toSongDownload = (id, br, name) => {
             document.body.appendChild(a);
             a.click();
             a.remove();
+            // Release after the click has been handed to the browser — the
+            // multi-MB blob stays pinned for the page lifetime otherwise.
+            setTimeout(() => window.URL.revokeObjectURL(url), 10_000);
             closeDownloadModal();
             downloadStatus.value = false;
             $message.success(t("general.message.downloadSuccess", { name }));

--- a/src/components/Player/PlayerCover.vue
+++ b/src/components/Player/PlayerCover.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="player-cover-container">
+  <div ref="coverContainerRef" class="player-cover-container">
     <div class="cover-stage">
       <div class="amll-close-action">
         <ControlThumb aria-label="Close player" @click="closeBigPlayer" />
@@ -346,40 +346,61 @@ const closeBigPlayer = () => {
 };
 
 // GSAP 动画
+// Scoped to this component's own buttons (a document-wide query would attach
+// to other components' .button-icon nodes and outlive this instance), and
+// removed on unmount so playerStyle toggles don't stack orphaned closures.
+const coverContainerRef = ref(null);
+const buttonAnimationCleanups = [];
+
 onMounted(() => {
-  const buttons = document.querySelectorAll(".button-icon");
+  const root = coverContainerRef.value;
+  if (!root) return;
+  const buttons = root.querySelectorAll(".button-icon");
   buttons.forEach((button) => {
-    // 悬停动画
-    button.addEventListener("mouseenter", () => {
+    const onMouseEnter = () => {
       gsap.to(button, {
         scale: 1.1,
         duration: 0.2,
         ease: "power1.out",
       });
-    });
-    button.addEventListener("mouseleave", () => {
+    };
+    const onMouseLeave = () => {
       gsap.to(button, {
         scale: 1,
         duration: 0.2,
         ease: "power1.inOut",
       });
-    });
-    // 点击动画
-    button.addEventListener("mousedown", () => {
+    };
+    const onMouseDown = () => {
       gsap.to(button, {
         scale: 0.9,
         duration: 0.1,
         ease: "power1.in",
       });
-    });
-    button.addEventListener("mouseup", () => {
+    };
+    const onMouseUp = () => {
       gsap.to(button, {
         scale: 1.1,
         duration: 0.2,
         ease: "power1.out",
       });
+    };
+    button.addEventListener("mouseenter", onMouseEnter);
+    button.addEventListener("mouseleave", onMouseLeave);
+    button.addEventListener("mousedown", onMouseDown);
+    button.addEventListener("mouseup", onMouseUp);
+    buttonAnimationCleanups.push(() => {
+      button.removeEventListener("mouseenter", onMouseEnter);
+      button.removeEventListener("mouseleave", onMouseLeave);
+      button.removeEventListener("mousedown", onMouseDown);
+      button.removeEventListener("mouseup", onMouseUp);
     });
   });
+});
+
+onUnmounted(() => {
+  buttonAnimationCleanups.forEach((cleanup) => cleanup());
+  buttonAnimationCleanups.length = 0;
 });
 </script>
 

--- a/src/components/Player/Spectrum.vue
+++ b/src/components/Player/Spectrum.vue
@@ -7,7 +7,7 @@
 
 <script setup>
 import { ensureSpectrumUpdate } from "@/utils/AudioContext";
-import { getSpectrumFrame } from "@/utils/AudioContext/SpectrumFrame";
+import { getSpectrumFrame, getSpectrumVersion } from "@/utils/AudioContext/SpectrumFrame";
 
 const props = defineProps({
   show: {
@@ -54,11 +54,15 @@ const updateCanvasSize = () => {
  * @param {Array} data - 包含音频频谱数据的数组
  */
 const drawSpectrum = (data) => {
-  if (!data || !data.length) return;
-
   const canvas = canvasRef.value;
   if (!canvas) return;
   const ctx = canvas.getContext("2d");
+  if (!data || !data.length) {
+    // Frame was cleared (pause/track change) — wipe the canvas once instead of
+    // leaving stale bars behind.
+    ctx.clearRect(0, 0, cachedWidth, cachedHeight);
+    return;
+  }
 
   const canvasWidth = cachedWidth;
   const canvasHeight = cachedHeight;
@@ -130,12 +134,26 @@ const addRoundRect = (ctx, x, y, width, height, radius) => {
 
 // Managed RAF loop. Keep it alive while mounted so opening BigPlayer can draw
 // the latest frame immediately after the user toggles spectrum display.
+// Two gates keep the loop from burning CPU when its output cannot be seen:
+// - version gate: skip the canvas work when no new spectrum frame arrived
+//   (paused / analysis stopped / background tab)
+// - show gate: BigPlayer slides off-screen via translateY(100%) when closed,
+//   taking this fixed-position canvas with it — after the slide transition
+//   settles there is nothing visible to draw, so the loop parks entirely
+//   until `show` flips back.
 let rafId = null;
+let lastDrawnVersion = -1;
+let hideParkTimer = null;
+const HIDE_PARK_DELAY_MS = 1000; // outlasts the 0.5s close transition
 
 const startDraw = () => {
   if (rafId) return;
   const loop = () => {
-    drawSpectrum(getSpectrumFrame());
+    const version = getSpectrumVersion();
+    if (version !== lastDrawnVersion) {
+      lastDrawnVersion = version;
+      drawSpectrum(getSpectrumFrame());
+    }
     rafId = requestAnimationFrame(loop);
   };
   loop();
@@ -148,14 +166,31 @@ const stopDraw = () => {
   }
 };
 
+const clearHideParkTimer = () => {
+  if (hideParkTimer) {
+    clearTimeout(hideParkTimer);
+    hideParkTimer = null;
+  }
+};
+
 // ResizeObserver to track canvas size changes
 let resizeObserver = null;
 
 watch(
   () => props.show,
-  () => {
+  (visible) => {
     updateCanvasSize();
     ensureSpectrumUpdate();
+    clearHideParkTimer();
+    if (visible) {
+      lastDrawnVersion = -1; // force an immediate redraw of the latest frame
+      startDraw();
+    } else {
+      hideParkTimer = setTimeout(() => {
+        hideParkTimer = null;
+        stopDraw();
+      }, HIDE_PARK_DELAY_MS);
+    }
   },
 );
 
@@ -169,10 +204,14 @@ onMounted(() => {
     resizeObserver.observe(canvasRef.value.parentElement);
   }
 
-  startDraw();
+  // Off-screen at mount (player closed) — the show watcher starts the loop.
+  if (props.show) {
+    startDraw();
+  }
 });
 
 onBeforeUnmount(() => {
+  clearHideParkTimer();
   stopDraw();
   if (resizeObserver) {
     resizeObserver.disconnect();

--- a/src/composables/useNativeMediaControls.ts
+++ b/src/composables/useNativeMediaControls.ts
@@ -124,6 +124,10 @@ export function useNativeMediaControls() {
   let unlistenAudioFocus: (() => void) | null = null;
   let lastPayloadHash = "";
   let lastProgressSyncAt = 0;
+  // Whether THIS instance holds the singleton slot. A non-claiming instance
+  // (mounted while another was active) must not decrement the shared counter
+  // on unmount, or the surviving instance is left permanently inert.
+  let claimedMediaControls = false;
 
   const PROGRESS_SYNC_INTERVAL = 5_000;
 
@@ -393,6 +397,7 @@ export function useNativeMediaControls() {
   onMounted(async () => {
     if (instanceCount > 0) return;
     instanceCount++;
+    claimedMediaControls = true;
 
     if (!isTauri()) return;
 
@@ -410,7 +415,10 @@ export function useNativeMediaControls() {
   });
 
   onUnmounted(() => {
-    instanceCount = Math.max(0, instanceCount - 1);
+    if (claimedMediaControls) {
+      claimedMediaControls = false;
+      instanceCount = Math.max(0, instanceCount - 1);
+    }
     unlistenMediaAction?.();
     unlistenMediaAction = null;
     unlistenAudioFocus?.();

--- a/src/libs/apple-music-like/LyricPlayer.vue
+++ b/src/libs/apple-music-like/LyricPlayer.vue
@@ -120,6 +120,12 @@ let syncFrameId = 0;
 let lyricFrameId = 0;
 let lastLyricFrameTime = -1;
 let lastSubmittedLyricTime = -1;
+// Park the AMLL spring/DOM work while the big player is closed: it slides
+// off-screen via translateY(100%), so per-frame updates are invisible. The
+// grace period covers the close transition; reopening resyncs via
+// scheduleCurrentTimeSync (same path as returning from a hidden tab).
+let lyricParkedSince = -1;
+const LYRIC_PARK_DELAY_MS = 1000;
 
 function applyPlayerSettings(player: DomLyricPlayer) {
   player.setEnableBlur(setting.lyricsBlur);
@@ -150,6 +156,16 @@ function updateLyricPlayer(frameTime: number) {
 
   const delta = lastLyricFrameTime < 0 ? 0 : frameTime - lastLyricFrameTime;
   lastLyricFrameTime = frameTime;
+
+  if (!music.showBigPlayer) {
+    if (lyricParkedSince < 0) lyricParkedSince = frameTime;
+    if (frameTime - lyricParkedSince > LYRIC_PARK_DELAY_MS) {
+      lyricFrameId = requestAnimationFrame(updateLyricPlayer);
+      return;
+    }
+  } else {
+    lyricParkedSince = -1;
+  }
 
   if (playState.value) {
     const lyricTime = Math.round(readPlaybackPosition() * 1000 + (setting.lyricTimeOffset ?? 0));
@@ -249,6 +265,15 @@ onBeforeUnmount(() => {
 watch(
   () => playState.value,
   (playing) => applyPlayback(playing),
+);
+
+// Reopening the big player after a parked stretch: jump the lyric view to the
+// live position instead of letting the spring animate across the gap.
+watch(
+  () => music.showBigPlayer,
+  (visible) => {
+    if (visible) scheduleCurrentTimeSync();
+  },
 );
 
 watch(

--- a/src/libs/fbm-renderer/fbm-renderer.ts
+++ b/src/libs/fbm-renderer/fbm-renderer.ts
@@ -391,6 +391,10 @@ export class FbmRenderer extends BaseRenderer {
     if (this.texCoordBuffer) gl.deleteBuffer(this.texCoordBuffer);
     if (this.indexBuffer) gl.deleteBuffer(this.indexBuffer);
     this.hasImage = false;
+    // The owning component creates a fresh canvas + webgl2 context per mount,
+    // and browsers cap live contexts (~16) with GC-timed reclamation — release
+    // this one eagerly so repeated mount cycles can't evict newer contexts.
+    gl.getExtension("WEBGL_lose_context")?.loseContext();
   }
 
   async setAlbum(albumSource: string | HTMLImageElement | HTMLVideoElement, _isVideo?: boolean) {

--- a/src/utils/AudioContext/AudioEffectManager.ts
+++ b/src/utils/AudioContext/AudioEffectManager.ts
@@ -319,6 +319,11 @@ export class AudioEffectManager {
     if (this._workletNode) {
       try {
         this._workletNode.port.onmessage = null;
+        // Tell the processor to return false from process() so the engine can
+        // retire it. A processor that keeps returning true is kept alive (and
+        // called every render quantum) forever, accumulating one zombie
+        // processor on the audio thread per unloaded track.
+        this._workletNode.port.postMessage("stop");
         this._workletNode.disconnect();
       } catch {
         /* already disconnected */

--- a/src/utils/AudioContext/AutoMix/CrossfadeScheduler.ts
+++ b/src/utils/AudioContext/AutoMix/CrossfadeScheduler.ts
@@ -257,6 +257,12 @@ export class CrossfadeScheduler {
     // Now safe to remove spectral filters
     this._spectralEQ.cleanupWithReconnect(this._outgoingGain, this._incomingGain);
 
+    // Release gain refs — holding the outgoing gain past this point keeps the
+    // unloaded track's audio-graph anchor (and anything wired to it) reachable
+    // until the next scheduleFullCrossfade overwrites the fields.
+    this._outgoingGain = null;
+    this._incomingGain = null;
+
     if (IS_DEV) {
       console.log("CrossfadeScheduler: Crossfade complete");
     }
@@ -473,6 +479,11 @@ export class CrossfadeScheduler {
 
     // Clean up spectral filters
     this._spectralEQ.cleanupWithReconnect(this._outgoingGain, this._incomingGain);
+
+    // Release gain refs (see _finish) — the 100ms ramps above are already
+    // scheduled on the AudioParams and are unaffected by dropping the JS refs.
+    this._outgoingGain = null;
+    this._incomingGain = null;
 
     this._isActive = false;
     this._isPaused = false;

--- a/src/utils/AudioContext/AutoMix/PreBufferManager.ts
+++ b/src/utils/AudioContext/AutoMix/PreBufferManager.ts
@@ -33,15 +33,18 @@ export class PreBufferManager {
   /**
    * Start pre-buffering the next track. Fire-and-forget.
    * @param musicStore - Music store reference
-   * @param analysisCache - Analysis cache map
+   * @param analysisCache - Analysis cache map (read-only here; writes go
+   * through `addToCache` so the owner's size cap always applies)
    * @param settings - Current settings
    * @param stateGetter - Function to check current AutoMix state (for bail-out)
+   * @param addToCache - Owner's capped cache-insert path
    */
   startPreBuffer(
     musicStore: any,
     analysisCache: Map<number, CachedAnalysis>,
     settings: { volumeNorm: boolean; bpmMatch: boolean },
     stateGetter: () => string,
+    addToCache: (entry: CachedAnalysis) => void,
   ): void {
     if (this._isBuffering || this._preBuffered) return;
 
@@ -131,9 +134,11 @@ export class PreBufferManager {
               const analysis = await analyzeTrack(blobUrl, { analyzeBPM: settings.bpmMatch });
               preBufferedAnalysis = { songId: nextSong.id, analysis };
               // Share with the state machine's cache so a discarded pre-buffer
-              // doesn't force a full re-decode of the same track later.
-              // (The cache is size-capped by its owner after every crossfade.)
-              analysisCache.set(nextSong.id, preBufferedAnalysis);
+              // doesn't force a full re-decode of the same track later. Must
+              // go through the owner's capped insert path: a direct Map.set
+              // would bypass eviction, and repeated skip/cancel churn (no
+              // crossfade ever completing) would grow the cache unbounded.
+              addToCache(preBufferedAnalysis);
             }
           } catch (err) {
             if (IS_DEV) console.warn("PreBufferManager: Analysis failed", err);

--- a/src/utils/AudioContext/AutoMix/PreBufferManager.ts
+++ b/src/utils/AudioContext/AutoMix/PreBufferManager.ts
@@ -24,6 +24,11 @@ interface PreBufferState {
 export class PreBufferManager {
   private _preBuffered: PreBufferState | null = null;
   private _isBuffering: boolean = false;
+  /** Bumped by cleanup() and each new pre-buffer chain. An in-flight
+   * doPreBuffer() whose epoch is stale must release its sound instead of
+   * publishing it — otherwise a cancel during download orphans a fully
+   * buffered song (Blob URL + ArrayBuffer never revoked). */
+  private _epoch: number = 0;
 
   /**
    * Start pre-buffering the next track. Fire-and-forget.
@@ -55,15 +60,17 @@ export class PreBufferManager {
     const nextSong = playlist[nextIndex];
     if (!nextSong) return;
 
+    this._isBuffering = true;
+    const epoch = ++this._epoch;
+
     const canContinue = (): boolean => {
+      if (epoch !== this._epoch) return false;
       const state = stateGetter();
       return (
         (state === "idle" || state === "analyzing" || state === "waiting") &&
         musicStore.persistData.playSongIndex === currentIndex
       );
     };
-
-    this._isBuffering = true;
 
     const doPreBuffer = async () => {
       // Step 1: Resolve music URL (unified: NCM + trial detection + UNM fallback)
@@ -123,6 +130,10 @@ export class PreBufferManager {
             if (blobUrl) {
               const analysis = await analyzeTrack(blobUrl, { analyzeBPM: settings.bpmMatch });
               preBufferedAnalysis = { songId: nextSong.id, analysis };
+              // Share with the state machine's cache so a discarded pre-buffer
+              // doesn't force a full re-decode of the same track later.
+              // (The cache is size-capped by its owner after every crossfade.)
+              analysisCache.set(nextSong.id, preBufferedAnalysis);
             }
           } catch (err) {
             if (IS_DEV) console.warn("PreBufferManager: Analysis failed", err);
@@ -153,7 +164,14 @@ export class PreBufferManager {
         return;
       }
 
-      // Store pre-buffered state
+      // Store pre-buffered state. Defensive: never orphan an existing buffer —
+      // with the epoch guard this should be unreachable, but an overwritten
+      // BufferedSound would leak its whole download.
+      if (this._preBuffered && this._preBuffered.sound !== sound) {
+        this._preBuffered.sound.stop();
+        this._preBuffered.sound.unload();
+        this._preBuffered = null;
+      }
       this._preBuffered = {
         sound,
         songIndex: nextIndex,
@@ -176,7 +194,11 @@ export class PreBufferManager {
         }
       })
       .finally(() => {
-        this._isBuffering = false;
+        // Only the live chain may clear the flag — a stale chain clearing it
+        // would re-open the startPreBuffer guard while a newer chain runs.
+        if (epoch === this._epoch) {
+          this._isBuffering = false;
+        }
       });
   }
 
@@ -207,6 +229,9 @@ export class PreBufferManager {
    * Clean up pre-buffered state. Safe to call at any time.
    */
   cleanup(): void {
+    // Invalidate any in-flight doPreBuffer() chain: its next canContinue()
+    // check fails and it releases its own sound.
+    this._epoch++;
     if (this._preBuffered) {
       this._preBuffered.sound.stop();
       this._preBuffered.sound.unload();

--- a/src/utils/AudioContext/AutoMix/SpectralEQ.ts
+++ b/src/utils/AudioContext/AutoMix/SpectralEQ.ts
@@ -206,15 +206,36 @@ export class SpectralEQ {
     const audioCtx = AudioContextManager.getContext();
     if (!audioCtx) return;
 
-    if (this._outgoingFilters.length > 0 && outgoingGain) {
-      this._removeFilterChain(outgoingGain, this._outgoingFilters, audioCtx);
+    // Even without the gain ref the filters must be disconnected and the
+    // arrays reset — otherwise the next setup() overwrites the arrays and
+    // orphans filters that are still wired to destination.
+    if (this._outgoingFilters.length > 0) {
+      if (outgoingGain) {
+        this._removeFilterChain(outgoingGain, this._outgoingFilters, audioCtx);
+      } else {
+        this._disconnectFilters(this._outgoingFilters);
+      }
       this._outgoingFilters = [];
     }
-    if (this._incomingFilters.length > 0 && incomingGain) {
-      this._removeFilterChain(incomingGain, this._incomingFilters, audioCtx);
+    if (this._incomingFilters.length > 0) {
+      if (incomingGain) {
+        this._removeFilterChain(incomingGain, this._incomingFilters, audioCtx);
+      } else {
+        this._disconnectFilters(this._incomingFilters);
+      }
       this._incomingFilters = [];
     }
     this._spectralData = null;
+  }
+
+  private _disconnectFilters(filters: BiquadFilterNode[]): void {
+    for (const f of filters) {
+      try {
+        f.disconnect();
+      } catch {
+        /* already disconnected */
+      }
+    }
   }
 
   get hasFilters(): boolean {

--- a/src/utils/AudioContext/AutoMix/TrackAnalyzerWorkerClient.ts
+++ b/src/utils/AudioContext/AutoMix/TrackAnalyzerWorkerClient.ts
@@ -39,6 +39,11 @@ function getWorker(): Worker | null {
         pending.reject(new Error("Worker error"));
         pendingRequests.delete(id);
       }
+      // Retire the broken worker so the next request spawns a fresh one —
+      // keeping it would make every subsequent analysis burn its full
+      // timeout against a dead worker.
+      worker?.terminate();
+      worker = null;
     };
 
     if (IS_DEV) {
@@ -148,5 +153,10 @@ export function terminateAnalysisWorker(): void {
     worker.terminate();
     worker = null;
   }
-  pendingRequests.clear();
+  // Reject instead of dropping: a cleared-but-unsettled promise retains its
+  // await continuations (and whatever sounds/buffers they capture) forever.
+  for (const [id, pending] of pendingRequests) {
+    pending.reject(new Error("Analysis worker terminated"));
+    pendingRequests.delete(id);
+  }
 }

--- a/src/utils/AudioContext/AutoMix/TransitionEffects.ts
+++ b/src/utils/AudioContext/AutoMix/TransitionEffects.ts
@@ -67,6 +67,14 @@ export class TransitionEffects {
     startTime: number,
     crossfadeDuration: number,
   ): void {
+    // Guard: release any previous reverb nodes before overwriting the refs —
+    // an overwritten convolver stays wired to its source and can't be reclaimed
+    if (this._convolver || this._reverbGain) {
+      if (IS_DEV) {
+        console.warn("TransitionEffects: Previous reverb tail still active, cleaning up first");
+      }
+      this._teardownReverb();
+    }
     // Clamp decay time
     decayTime = Math.max(1.5, Math.min(3.0, decayTime));
 
@@ -266,6 +274,13 @@ export class TransitionEffects {
     bpm?: number,
     targetFreq: number = 2000,
   ): void {
+    // Guard: release any previous riser before overwriting the refs
+    if (this._noiseSource || this._noiseFilter || this._riserGain) {
+      if (IS_DEV) {
+        console.warn("TransitionEffects: Previous noise riser still active, cleaning up first");
+      }
+      this._teardownRiser();
+    }
     // Beat-sync duration if BPM available
     if (bpm && bpm > 0) {
       const beatDuration = 60 / bpm;
@@ -331,6 +346,13 @@ export class TransitionEffects {
     bpm?: number,
     intensity: number = 0.5,
   ): void {
+    // Guard: release any previous swell before overwriting the refs
+    if (this._reverseSource || this._reverseFilter || this._reverseGain) {
+      if (IS_DEV) {
+        console.warn("TransitionEffects: Previous reverse swell still active, cleaning up first");
+      }
+      this._teardownSwell();
+    }
     if (bpm && bpm > 0) {
       const beatDuration = 60 / bpm;
       const beats = Math.max(1, Math.round(duration / beatDuration));
@@ -398,6 +420,13 @@ export class TransitionEffects {
     bpm?: number,
     intensity: number = 0.5,
   ): void {
+    // Guard: release any previous echo chain before overwriting the refs
+    if (this._echoDelay || this._echoFeedback || this._echoFilter || this._echoGain) {
+      if (IS_DEV) {
+        console.warn("TransitionEffects: Previous echo throw still active, cleaning up first");
+      }
+      this._teardownEcho();
+    }
     duration = Math.max(0.8, Math.min(4.0, duration));
     intensity = Math.max(0, Math.min(1, intensity));
 
@@ -577,12 +606,20 @@ export class TransitionEffects {
   }
 
   /**
-   * Clean up all effect nodes, disconnecting from the audio graph.
+   * Tear down the reverb send: outgoingGain → convolver → reverbGain → destination.
+   * The upstream edge must be severed while the convolver ref is still alive —
+   * otherwise the outgoing GainNode keeps the convolver (and its IR buffer)
+   * reachable for as long as the gain node lives.
    */
-  cleanup(): void {
-    // Get AudioContext for reconnecting gain nodes after sweep filter removal
-    const ctx = AudioContextManager.getContext();
-
+  private _teardownReverb(): void {
+    if (this._reverbConnectedTo && this._convolver) {
+      try {
+        this._reverbConnectedTo.disconnect(this._convolver);
+      } catch {
+        /* ok */
+      }
+    }
+    this._reverbConnectedTo = null;
     if (this._convolver) {
       try {
         this._convolver.disconnect();
@@ -599,10 +636,9 @@ export class TransitionEffects {
       }
       this._reverbGain = null;
     }
-    // Disconnect reverb parallel connection from outgoing gain
-    // (don't disconnect outgoingGain entirely — it's still used by the main chain)
-    this._reverbConnectedTo = null;
+  }
 
+  private _teardownRiser(): void {
     if (this._noiseSource) {
       try {
         this._noiseSource.stop();
@@ -632,7 +668,9 @@ export class TransitionEffects {
       }
       this._riserGain = null;
     }
+  }
 
+  private _teardownSwell(): void {
     if (this._reverseSource) {
       try {
         this._reverseSource.stop();
@@ -662,7 +700,9 @@ export class TransitionEffects {
       }
       this._reverseGain = null;
     }
+  }
 
+  private _teardownEcho(): void {
     if (this._echoConnectedTo && this._echoDelay) {
       try {
         this._echoConnectedTo.disconnect(this._echoDelay);
@@ -703,6 +743,22 @@ export class TransitionEffects {
       }
       this._echoGain = null;
     }
+  }
+
+  /**
+   * Clean up all effect nodes, disconnecting from the audio graph.
+   * @param reconnectOutgoing - restore the outgoing gain's direct route to
+   * destination after removing the sweep filter. Required on the cancel path,
+   * where the outgoing sound is reverted to current and keeps playing.
+   */
+  cleanup(reconnectOutgoing = false): void {
+    // Get AudioContext for reconnecting gain nodes after sweep filter removal
+    const ctx = AudioContextManager.getContext();
+
+    this._teardownReverb();
+    this._teardownRiser();
+    this._teardownSwell();
+    this._teardownEcho();
 
     if (this._gateGain) {
       try {
@@ -727,8 +783,10 @@ export class TransitionEffects {
     this._gateConnectedTo = null;
 
     // Clean up filter sweep: disconnect filters and reconnect gain nodes → destination
-    // Note: outgoing gain is NOT reconnected — it's about to be stopped/unloaded
-    // by _onCrossfadeComplete. Only the incoming gain needs reconnection.
+    // On the complete path the outgoing gain is NOT reconnected — the sound is
+    // about to be stopped/unloaded by _onCrossfadeComplete. On the cancel path
+    // (`reconnectOutgoing`) the outgoing sound is reverted to current and must
+    // get its direct route to destination back, or it plays silently.
     if (this._outSweepFilter) {
       try {
         this._outSweepFilter.disconnect();
@@ -741,7 +799,13 @@ export class TransitionEffects {
         } catch {
           /* ok */
         }
-        // Don't reconnect outgoing to destination — sound is being destroyed
+        if (reconnectOutgoing && ctx) {
+          try {
+            this._outSweepGainRef.connect(ctx.destination);
+          } catch {
+            /* ok */
+          }
+        }
       }
       this._outSweepFilter = null;
     }

--- a/src/utils/AudioContext/AutoMix/TransitionStateMachine.ts
+++ b/src/utils/AudioContext/AutoMix/TransitionStateMachine.ts
@@ -118,6 +118,11 @@ export class TransitionStateMachine {
   // Async guard: prevent duplicate analysis
   private _analyzingInFlight: boolean = false;
 
+  // Invalidates in-flight _doAnalysis chains: cancelCrossfade() clears
+  // `_analyzingInFlight` while the old promise is still awaiting, so its
+  // settle handlers must not touch the state of a newer analysis cycle.
+  private _analysisGeneration: number = 0;
+
   // Failure cooldown: prevent retry loops after crossfade failure
   private _lastFailureTime: number = 0;
 
@@ -745,10 +750,12 @@ export class TransitionStateMachine {
 
     this._state = "analyzing";
     this._analyzingInFlight = true;
+    const generation = ++this._analysisGeneration;
     this._updateStoreState();
 
-    this._doAnalysis()
+    this._doAnalysis(generation)
       .then(() => {
+        if (generation !== this._analysisGeneration) return;
         if (this._state === "analyzing") {
           this._state = "waiting";
           this._updateStoreState();
@@ -761,6 +768,7 @@ export class TransitionStateMachine {
             err,
           );
         }
+        if (generation !== this._analysisGeneration) return;
         if (this._state === "analyzing") {
           this._currentAnalysis = null;
           this._nextAnalysis = null;
@@ -770,11 +778,13 @@ export class TransitionStateMachine {
         }
       })
       .finally(() => {
-        this._analyzingInFlight = false;
+        if (generation === this._analysisGeneration) {
+          this._analyzingInFlight = false;
+        }
       });
   }
 
-  private async _doAnalysis(): Promise<void> {
+  private async _doAnalysis(generation: number): Promise<void> {
     const music = this._musicStoreRef;
     if (!music) return;
 
@@ -790,10 +800,12 @@ export class TransitionStateMachine {
           const analysis = await analyzeTrack(analysisUrl, {
             analyzeBPM: this._settingsBpmMatch,
           });
+          if (generation !== this._analysisGeneration) return;
           this._currentAnalysis = { songId: currentSong.id, analysis };
           this._addToCache(this._currentAnalysis);
         } catch (err) {
           if (IS_DEV) console.warn("TransitionStateMachine: Current track analysis failed", err);
+          if (generation !== this._analysisGeneration) return;
         }
       }
     } else if (currentSong && this._analysisCache.has(currentSong.id)) {
@@ -1921,7 +1933,9 @@ export class TransitionStateMachine {
     }
 
     this._crossfadeScheduler.cancel();
-    this._transitionEffects.cleanup();
+    // reconnectOutgoing: revertTransition below restores the outgoing sound as
+    // current, so its gain must be routed back to destination.
+    this._transitionEffects.cleanup(true);
 
     if (this._softwareFadeTimerId !== null) {
       clearTimeout(this._softwareFadeTimerId);
@@ -1975,6 +1989,9 @@ export class TransitionStateMachine {
     this._incomingSourceUrl = null;
 
     this._analyzingInFlight = false;
+    // Invalidate any in-flight _doAnalysis so its settle handlers become no-ops
+    // instead of corrupting the state of the next analysis cycle.
+    this._analysisGeneration++;
     this._nextAnalysis = null;
     this._lastStrategy = null;
     this._pendingNextIndex = -1;
@@ -2142,8 +2159,17 @@ export class TransitionStateMachine {
       let analysisUrl = this._getSoundAnalysisUrl(sound);
       if (!analysisUrl && sound instanceof BufferedSound) {
         await new Promise<void>((resolve) => {
-          sound.once("load", resolve);
-          setTimeout(resolve, 30000);
+          const onLoad = (): void => {
+            clearTimeout(timer);
+            resolve();
+          };
+          // Clear whichever side loses the race: a live 30s timer pins the
+          // sound via this closure; a stale listener lingers until unload.
+          const timer = setTimeout(() => {
+            sound.off("load", onLoad);
+            resolve();
+          }, 30000);
+          sound.once("load", onLoad);
         });
         analysisUrl = this._getSoundAnalysisUrl(sound);
       }

--- a/src/utils/AudioContext/AutoMix/TransitionStateMachine.ts
+++ b/src/utils/AudioContext/AutoMix/TransitionStateMachine.ts
@@ -1315,6 +1315,7 @@ export class TransitionStateMachine {
         this._analysisCache,
         { volumeNorm: this._settingsVolumeNorm, bpmMatch: this._settingsBpmMatch },
         () => this._state,
+        (entry) => this._addToCache(entry),
       );
       // Store pre-buffered analysis for _finalizeCrossfadeParams()
       if (this._preBufferManager.preBufferedAnalysis) {
@@ -2149,6 +2150,7 @@ export class TransitionStateMachine {
       this._analysisCache,
       { volumeNorm: this._settingsVolumeNorm, bpmMatch: this._settingsBpmMatch },
       () => this._state,
+      (entry) => this._addToCache(entry),
     );
   }
 

--- a/src/utils/AudioContext/NativeSound.ts
+++ b/src/utils/AudioContext/NativeSound.ts
@@ -540,8 +540,14 @@ export class NativeSound implements ISound {
         const index = listeners.indexOf(callback);
         if (index > -1) listeners.splice(index, 1);
       }
+      const onceListeners = this._onceListeners.get(event);
+      if (onceListeners) {
+        const index = onceListeners.indexOf(callback);
+        if (index > -1) onceListeners.splice(index, 1);
+      }
     } else {
       this._eventListeners.delete(event);
+      this._onceListeners.delete(event);
     }
     return this;
   }

--- a/src/utils/AudioContext/PlayerFunctions.ts
+++ b/src/utils/AudioContext/PlayerFunctions.ts
@@ -884,6 +884,9 @@ const setupNativeSound = (
     if (autoMix.isCrossfading()) return;
     checkpointActivePosition(sound, music);
     stopTimeUpdate();
+    // No audio flows while paused — park the per-frame analysis loop instead
+    // of polling FFT/lowfreq at 60fps. The play handler restarts it.
+    stopSpectrumUpdate();
     if (IS_DEV) console.log("[Native] 音乐暂停");
     music.setPlayState(false);
     window.$setSiteTitle("");
@@ -1207,6 +1210,9 @@ export const createSound = (
       }
       checkpointActivePosition(sound, music);
       stopTimeUpdate();
+      // No audio flows while paused — park the per-frame analysis loop instead
+      // of polling FFT/lowfreq at 60fps. The play handler restarts it.
+      stopSpectrumUpdate();
       if (IS_DEV) {
         console.log("音乐暂停");
       }
@@ -1482,6 +1488,9 @@ export const adoptIncomingSound = (incomingSound: ISound): void => {
     }
     checkpointActivePosition(incomingSound, music);
     stopTimeUpdate();
+    // No audio flows while paused — park the per-frame analysis loop instead
+    // of polling FFT/lowfreq at 60fps. The play handler restarts it.
+    stopSpectrumUpdate();
     if (IS_DEV) {
       console.log("音乐暂停 (adopted sound)");
     }

--- a/src/utils/AudioContext/pcm-capture-worklet.ts
+++ b/src/utils/AudioContext/pcm-capture-worklet.ts
@@ -14,8 +14,13 @@ class PCMCaptureProcessor extends AudioWorkletProcessor {
     super();
     this._buffer = new Float32Array(512);
     this._offset = 0;
+    this._stopped = false;
+    this.port.onmessage = (e) => {
+      if (e.data === "stop") this._stopped = true;
+    };
   }
   process(inputs) {
+    if (this._stopped) return false;
     const input = inputs[0];
     if (!input || !input[0] || input[0].length === 0) return true;
 

--- a/src/utils/color/coverPalette.ts
+++ b/src/utils/color/coverPalette.ts
@@ -35,7 +35,10 @@ export interface CoverPalette {
 
 const DEFAULT_RGB: RGB = [128, 128, 128];
 const DEFAULT_SOURCE_RGB: RGB = [98, 102, 116];
+// LRU-capped: every played track and every visited album/playlist/artist page
+// inserts an entry, so an uncapped map grows for the whole session.
 const PALETTE_CACHE = new Map<string, Promise<CoverPalette>>();
+const PALETTE_CACHE_MAX_ENTRIES = 96;
 
 const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
 const roundChannel = (value: number) => Math.round(clamp(value, 0, 255));
@@ -323,7 +326,12 @@ export const getCoverPalette = (coverSrc: string): Promise<CoverPalette> => {
 
   const normalizedSrc = normalizeCoverUrl(coverSrc);
   const cached = PALETTE_CACHE.get(normalizedSrc);
-  if (cached) return cached;
+  if (cached) {
+    // Refresh recency so hot covers survive eviction
+    PALETTE_CACHE.delete(normalizedSrc);
+    PALETTE_CACHE.set(normalizedSrc, cached);
+    return cached;
+  }
 
   const request = loadImage(normalizedSrc)
     .then(extractCoverPalette)
@@ -332,6 +340,11 @@ export const getCoverPalette = (coverSrc: string): Promise<CoverPalette> => {
       return getFallbackPalette();
     });
 
+  while (PALETTE_CACHE.size >= PALETTE_CACHE_MAX_ENTRIES) {
+    const oldest = PALETTE_CACHE.keys().next().value;
+    if (oldest === undefined) break;
+    PALETTE_CACHE.delete(oldest);
+  }
   PALETTE_CACHE.set(normalizedSrc, request);
   return request;
 };

--- a/src/utils/lyricFetcher.ts
+++ b/src/utils/lyricFetcher.ts
@@ -3,7 +3,10 @@ import { parseLyricData, formatAsLrc } from "@/utils/LyricsProcessor";
 import type { ParsedLyricResult } from "@/utils/LyricsProcessor";
 import useSettingDataStore from "@/store/settingData";
 
-const MAX_CACHE_SIZE = 50;
+// Keep this small: cached entries are mutated in place downstream (the store
+// attaches lrcAMData / processedLyrics to them), so each slot can grow to
+// hundreds of KB for word-by-word tracks. 50 slots plateaued at ~10-25 MB.
+const MAX_CACHE_SIZE = 20;
 
 interface CacheEntry {
   result: ParsedLyricResult;

--- a/src/utils/tauri/playerBridge.ts
+++ b/src/utils/tauri/playerBridge.ts
@@ -95,6 +95,10 @@ export function usePlayerBridge() {
   const lyricIndex = ref(-1);
 
   const unlisteners: (() => void)[] = [];
+  // Bumped by disconnect(): listeners still resolving from an interrupted
+  // connect() must release themselves instead of pushing into the cleared
+  // unlisteners array (which would orphan the Tauri subscription).
+  let connectSession = 0;
   let lastAcceptedTimeSeq = 0;
   let lastAcceptedTimeSongId: number | null = null;
   // Last authoritative time anchor (already latency-compensated). The local
@@ -178,6 +182,7 @@ export function usePlayerBridge() {
   async function connect(): Promise<void> {
     const tauri = getTauri();
     if (!tauri || unlisteners.length > 0) return;
+    const session = connectSession;
 
     // Local extrapolation between the master's sparse time anchors. Skips
     // work while hidden (consumers' RAF loops are paused then anyway) and
@@ -201,56 +206,62 @@ export function usePlayerBridge() {
     document.addEventListener("visibilitychange", onVisibilityChange);
     unlisteners.push(() => document.removeEventListener("visibilitychange", onVisibilityChange));
 
+    // Registers an async-acquired listener, or releases it immediately when
+    // disconnect() ran while the listen() call was still in flight — pushing
+    // into the already-cleared array would leak the Tauri subscription.
+    const track = (unlisten: () => void): void => {
+      if (session !== connectSession) {
+        unlisten();
+        return;
+      }
+      unlisteners.push(unlisten);
+    };
+
     // Player state (song metadata, playback state, etc.)
-    const u1 = await tauri.event.listen<PlayerStatePayload>(
-      PLAYER_COMMUNICATION_EVENTS.state,
-      (e) => {
+    track(
+      await tauri.event.listen<PlayerStatePayload>(PLAYER_COMMUNICATION_EVENTS.state, (e) => {
         applyStatePayload(e.payload);
-      },
+      }),
     );
-    unlisteners.push(u1);
 
     // Time anchors (discontinuities + low-rate heartbeat; extrapolated locally)
-    const u2 = await tauri.event.listen<PlayerTimePayload>(
-      PLAYER_COMMUNICATION_EVENTS.time,
-      (e) => {
+    track(
+      await tauri.event.listen<PlayerTimePayload>(PLAYER_COMMUNICATION_EVENTS.time, (e) => {
         applyTimePayload(e.payload);
-      },
+      }),
     );
-    unlisteners.push(u2);
 
     // Lyric data (once per song)
-    const u3 = await tauri.event.listen<PlayerLyricPayload>(
-      PLAYER_COMMUNICATION_EVENTS.lyric,
-      (e) => {
+    track(
+      await tauri.event.listen<PlayerLyricPayload>(PLAYER_COMMUNICATION_EVENTS.lyric, (e) => {
         lyricData.value = e.payload;
-      },
+      }),
     );
-    unlisteners.push(u3);
 
     // Settings changes
-    const u4 = await tauri.event.listen<PlayerSettingsPayload>(
-      PLAYER_COMMUNICATION_EVENTS.settings,
-      (e) => {
+    track(
+      await tauri.event.listen<PlayerSettingsPayload>(PLAYER_COMMUNICATION_EVENTS.settings, (e) => {
         Object.assign(settings, e.payload);
-      },
+      }),
     );
-    unlisteners.push(u4);
 
     // Full state snapshot (response to slave-window-opened)
-    const u5 = await tauri.event.listen<PlayerFullStatePayload>(
-      PLAYER_COMMUNICATION_EVENTS.fullState,
-      (e) => {
-        if (isStaleTimePayload(e.payload.time)) return;
-        applyStatePayload(e.payload.state);
-        applyTimePayload(e.payload.time);
-        if (e.payload.lyric) {
-          lyricData.value = e.payload.lyric;
-        }
-        Object.assign(settings, e.payload.settings);
-      },
+    track(
+      await tauri.event.listen<PlayerFullStatePayload>(
+        PLAYER_COMMUNICATION_EVENTS.fullState,
+        (e) => {
+          if (isStaleTimePayload(e.payload.time)) return;
+          applyStatePayload(e.payload.state);
+          applyTimePayload(e.payload.time);
+          if (e.payload.lyric) {
+            lyricData.value = e.payload.lyric;
+          }
+          Object.assign(settings, e.payload.settings);
+        },
+      ),
     );
-    unlisteners.push(u5);
+
+    if (session !== connectSession) return;
 
     // Notify master that we're ready
     const routePath = window.location.hash || window.location.pathname;
@@ -275,6 +286,7 @@ export function usePlayerBridge() {
   }
 
   function disconnect(): void {
+    connectSession++;
     unlisteners.forEach((fn) => fn());
     unlisteners.length = 0;
   }

--- a/src/utils/tauri/playerCommunication.ts
+++ b/src/utils/tauri/playerCommunication.ts
@@ -74,11 +74,14 @@ let cachedLyricSettingsKey = "";
 let cachedLyricPayload: PlayerLyricPayload | null = null;
 
 // Which content windows (mini-player / desktop-lyrics / taskbar-lyric) are
-// currently open. The 20fps time broadcast is skipped entirely when this is
-// empty, and only fans out to the labels that are actually open — so the
-// common case (no lyric/mini windows) costs nothing, and one open window costs
-// one `emitTo` instead of three.
+// currently open AND visible. The 20fps time broadcast is skipped entirely
+// when this is empty, and only fans out to the labels that are actually open —
+// so the common case (no lyric/mini windows) costs nothing, and one open
+// window costs one `emitTo` instead of three. Hidden-but-alive windows count
+// as closed: Rust announces show/hide via `managed-window-visibility`, and a
+// re-shown window is healed with a full-state push.
 const openContentWindows = new Set<string>();
+let openContentLabelsCache: string[] | null = null;
 let contentWindowReconcileTimer: ReturnType<typeof setInterval> | null = null;
 
 function getMusic() {
@@ -118,19 +121,37 @@ function isContentWindowLabel(label: string): boolean {
   return (PLAYER_CONTENT_WINDOW_LABELS as readonly string[]).includes(label);
 }
 
-/** Labels of content windows believed open, in canonical order. */
+/** Labels of content windows believed open, in canonical order. Cached — the
+ * 30Hz time-broadcast path calls this per tick, so recomputing the filter
+ * would allocate ~100k throwaway arrays per hour. */
 function openContentBroadcastLabels(): string[] {
-  return PLAYER_CONTENT_WINDOW_LABELS.filter((label) => openContentWindows.has(label));
+  openContentLabelsCache ??= PLAYER_CONTENT_WINDOW_LABELS.filter((label) =>
+    openContentWindows.has(label),
+  );
+  return openContentLabelsCache;
+}
+
+function addContentWindow(label: string): boolean {
+  if (openContentWindows.has(label)) return false;
+  openContentWindows.add(label);
+  openContentLabelsCache = null;
+  return true;
+}
+
+function removeContentWindow(label: string): void {
+  if (openContentWindows.delete(label)) {
+    openContentLabelsCache = null;
+  }
 }
 
 /**
  * Mark a content window open. Called from the `slaveReady` handshake, which the
  * slave re-sends with retries — so opens are never missed. Closes are handled
- * by the reconcile loop, so this only ever *adds*.
+ * by the visibility events plus the reconcile loop, so this only ever *adds*.
  */
 function markContentWindowOpen(label: string): void {
   if (!isContentWindowLabel(label)) return;
-  openContentWindows.add(label);
+  addContentWindow(label);
   ensureContentWindowReconcile();
 }
 
@@ -141,32 +162,45 @@ function ensureContentWindowReconcile(): void {
   }, CONTENT_WINDOW_RECONCILE_MS);
 }
 
+function stopContentWindowReconcileIfIdle(): void {
+  if (openContentWindows.size === 0 && contentWindowReconcileTimer !== null) {
+    clearInterval(contentWindowReconcileTimer);
+    contentWindowReconcileTimer = null;
+  }
+}
+
 /**
- * Prune content windows that have closed. Never *under-reports* open windows:
- * on a failed/empty window query we keep the current belief so a live slave is
- * never starved of updates. When nothing is open, the reconcile loop stops
- * (opens restart it via `markContentWindowOpen`).
+ * Reconcile the open-window belief against real window state. A window counts
+ * as open only while it exists AND is visible — a hidden-but-alive window
+ * (e.g. mini-player toggled away) must not keep the heartbeat/broadcast
+ * machinery running for the rest of the session. Never *under-reports* on a
+ * failed query: keep the current belief so a live slave is never starved.
+ * When nothing is open, the reconcile loop stops (opens restart it via
+ * `markContentWindowOpen` or the visibility event).
  */
 async function reconcileContentWindows(): Promise<void> {
-  const open = await windowManager.listWindows().catch(() => null);
-  if (open) {
-    const openSet = new Set(open);
-    for (const label of openContentWindows) {
-      if (!openSet.has(label)) openContentWindows.delete(label);
-    }
-    // Pick up any content window that opened without a handshake (safety net).
-    for (const label of PLAYER_CONTENT_WINDOW_LABELS) {
-      if (openSet.has(label)) openContentWindows.add(label);
+  const states = await Promise.all(
+    PLAYER_CONTENT_WINDOW_LABELS.map(async (label) => ({
+      label,
+      state: await windowManager.getWindowState(label).catch(() => null),
+    })),
+  );
+  for (const { label, state } of states) {
+    if (!state) continue;
+    if (state.exists && state.visible) {
+      // Discovered outside the handshake (master reload while slaves stayed
+      // open, missed visibility event) — heal it with a full-state push.
+      if (addContentWindow(label)) {
+        broadcastPlayerFullState(label);
+      }
+    } else {
+      removeContentWindow(label);
     }
   }
-  if (openContentWindows.size === 0) {
-    if (contentWindowReconcileTimer !== null) {
-      clearInterval(contentWindowReconcileTimer);
-      contentWindowReconcileTimer = null;
-    }
-  } else {
-    // Windows discovered outside the handshake (e.g. a master reload while
-    // slaves stayed open) must still be pruned when they close later.
+  stopContentWindowReconcileIfIdle();
+  if (openContentWindows.size > 0) {
+    // Windows discovered outside the handshake must still be pruned when they
+    // close later.
     ensureContentWindowReconcile();
   }
 }
@@ -225,14 +259,29 @@ function buildLrcPayload(songLyric: SongLyric) {
   return Array.isArray(songLyric.lrc) ? songLyric.lrc : [];
 }
 
+function clearLyricBroadcastCache(): void {
+  cachedLyricSource = null;
+  cachedLyricSongId = null;
+  cachedLyricSettingsKey = "";
+  cachedLyricPayload = null;
+}
+
 function buildPlayerLyricPayload(force = false): PlayerLyricPayload | null {
   const music = getMusic();
   const setting = getSetting();
   const songData = music.getPlaySongData;
-  if (!songData) return null;
+  if (!songData) {
+    // Queue cleared — drop the module-level refs so the previous track's
+    // lyric payload doesn't stay pinned after the store has reset.
+    clearLyricBroadcastCache();
+    return null;
+  }
 
   const songLyric = toRaw(music.songLyric) as SongLyric | null;
-  if (!songLyric) return null;
+  if (!songLyric) {
+    clearLyricBroadcastCache();
+    return null;
+  }
 
   const settingsKey = lyricSettingsKey(setting);
   if (
@@ -362,18 +411,21 @@ export function broadcastPlayerTime(force = false) {
 
 export function broadcastPlayerLyrics(force = false) {
   if (!isTauri()) return;
+  // Only visible content windows need the payload — anything (re)opening later
+  // is healed by the full-state push, so skip the (expensive) payload build
+  // and the per-window IPC serialization entirely when none is visible.
+  const labels = openContentBroadcastLabels();
+  if (labels.length === 0) return;
   const payload = buildPlayerLyricPayload(force);
   if (!payload) return;
-  emitToLabels(PLAYER_COMMUNICATION_EVENTS.lyric, payload, PLAYER_CONTENT_WINDOW_LABELS);
+  emitToLabels(PLAYER_COMMUNICATION_EVENTS.lyric, payload, labels);
 }
 
 export function broadcastPlayerSettings() {
   if (!isTauri()) return;
-  emitToLabels(
-    PLAYER_COMMUNICATION_EVENTS.settings,
-    buildPlayerSettingsPayload(),
-    PLAYER_CONTENT_WINDOW_LABELS,
-  );
+  const labels = openContentBroadcastLabels();
+  if (labels.length === 0) return;
+  emitToLabels(PLAYER_COMMUNICATION_EVENTS.settings, buildPlayerSettingsPayload(), labels);
 }
 
 export function broadcastPlayerFullState(targetLabel: string) {
@@ -491,12 +543,30 @@ export async function setupMainPlayerCommunication(options: MainPlayerCommunicat
     }
   });
 
+  // Rust announces show/hide of managed windows. Hidden slaves drop out of the
+  // broadcast set (stopping the heartbeat/reconcile machinery when nothing is
+  // visible); re-shown slaves rejoin and are healed with a full-state push —
+  // they don't re-run the slaveReady handshake because the page never reloads.
+  await tauri.event.listen<{ label?: unknown; visible?: unknown }>(
+    "managed-window-visibility",
+    (event) => {
+      const label = event.payload?.label;
+      const visible = event.payload?.visible;
+      if (typeof label !== "string" || typeof visible !== "boolean") return;
+      if (!isContentWindowLabel(label)) return;
+      if (visible) {
+        const added = addContentWindow(label);
+        ensureContentWindowReconcile();
+        if (added) broadcastPlayerFullState(label);
+      } else {
+        removeContentWindow(label);
+        stopContentWindowReconcileIfIdle();
+      }
+    },
+  );
+
   // Master (re)started while slave windows were already open (reload, crash
   // recovery): they never re-handshake, so discover them and re-push the full
-  // state — otherwise they keep stale lyrics/settings until the next song.
-  void reconcileContentWindows().then(() => {
-    for (const label of openContentBroadcastLabels()) {
-      broadcastPlayerFullState(label);
-    }
-  });
+  // state — reconcileContentWindows heals newly discovered windows inline.
+  void reconcileContentWindows();
 }

--- a/src/views/DesktopLyrics/index.vue
+++ b/src/views/DesktopLyrics/index.vue
@@ -1182,6 +1182,13 @@ async function startMouseThrough() {
 
   mouseThroughActive.value = true;
 
+  // Release any previous subscription first — a lock→lock sequence would
+  // otherwise overwrite the handle and orphan the old Rust event listener.
+  if (unlistenMouseThrough) {
+    unlistenMouseThrough();
+    unlistenMouseThrough = null;
+  }
+
   // Listen for state changes from Rust
   unlistenMouseThrough = await tauri.event.listen<boolean>("mouse-through-state", (e) => {
     // e.payload = true when cursor is inside a hit region


### PR DESCRIPTION
前端（Web/Tauri 共用）:
- pcm-capture-worklet: 断开时通知处理器 return false，避免每首歌残留一个常驻音频线程处理器
- PreBufferManager: epoch 令牌防止取消后孤儿化整首预缓冲歌曲（Blob URL/ArrayBuffer 无法回收）
- TransitionEffects: 补上混响并联边(outgoingGain→convolver)的断开；取消路径重连 outgoing gain 到 destination（原先回退后静音）；四个效果创建方法补覆盖守卫
- CrossfadeScheduler: 完成/取消后释放 gain 引用；SpectralEQ 在 gain 缺失时也断开并清空滤波器数组
- TransitionStateMachine: 分析 generation 令牌防止取消后陈旧回调污染新分析周期；预分析 30s 定时器竞态清理
- TrackAnalyzerWorkerClient: worker 出错后销毁重建（原先每次分析空耗完整超时）；terminate 时 reject 挂起 promise
- Spectrum/LyricPlayer: BigPlayer 关闭（translateY 滑出屏幕）后停驻每帧 canvas 绘制与 AMLL spring/DOM 更新，重开时即时重同步；暂停时停掉 60fps 频谱分析循环
- coverPalette: PALETTE_CACHE 增加 LRU 上限（原先随播放与页面浏览无界增长）
- lyricFetcher: 缓存槽位 50→20（条目被下游就地扩展为数百 KB）
- playerCommunication: 隐藏子窗口不再永久保活心跳与 reconcile 轮询（按可见性门控 + full-state 修复）；广播标签数组缓存消除 30Hz 分配；歌词/设置广播仅发给可见窗口；无歌曲时清理歌词负载缓存
- playerBridge: connect/unmount 竞态下不再孤儿化 Tauri 监听器
- PlayerCover: 按钮动画监听器作用域化到组件自身并在卸载时移除
- fbm-renderer: dispose 时显式 loseContext 释放 WebGL 上下文
- DownloadSong: 下载完成后 revoke Blob URL
- DesktopLyrics: 重复锁定不再泄漏 mouse-through 事件订阅
- NativeSound.off: 支持移除 once 监听器

Rust (Tauri):
- mouse_through: rdev 全局钩子改为进程级单例（原先每次锁定切换泄漏一个无法停止的钩子线程，鼠标移动 CPU 随切换次数线性增长）
- queue: AutoMix 完成回调按曲目身份替换而非无限追加
- automix: 解码单声道按时长提示预留容量，消除数千万样本的翻倍重分配
- api: 无轮询消费者时跳过 event_buf 的逐事件克隆
- manager: 广播 managed-window-visibility 供主窗口按可见性门控子窗口广播