### PR TITLE
Fix word timing collapse in LyricsProcessor for accurate highlighting

### DIFF
--- a/src/utils/LyricsProcessor/index.ts
+++ b/src/utils/LyricsProcessor/index.ts
@@ -25,7 +25,12 @@ export type {
 } from "./types";
 
 // Time utilities
-export { parseLrcTime, formatLrcTime, detectYrcType } from "./timeUtils";
+export {
+  parseLrcTime,
+  formatLrcTime,
+  detectYrcType,
+  detectWordTimedLyricFormat,
+} from "./timeUtils";
 
 // Entry parsing
 export {

--- a/src/utils/LyricsProcessor/lyricParser.ts
+++ b/src/utils/LyricsProcessor/lyricParser.ts
@@ -4,7 +4,9 @@
  */
 
 import {
+  parseEslrc as parseAMLLEslrc,
   parseLrc as parseAMLLLrc,
+  parseQrc as parseAMLLQrc,
   parseYrc as parseAMLLYrc,
   type LyricLine as AMLLParsedLyricLine,
 } from "@applemusic-like-lyrics/lyric";
@@ -15,14 +17,27 @@ import {
   buildAMLLData,
 } from "./parser/formatParser";
 import { alignByIndex } from "./alignment";
-import { normalizeLrcTimestampText } from "./timeUtils";
+import { normalizeLrcTimestampText, detectWordTimedLyricFormat } from "./timeUtils";
 import type { RawLyricData, ParsedLyricResult } from "./types";
 
 type ParsedSourceLine = AMLLParsedLyricLine;
 
 const parseLrcText = (lyricText: string): ParsedSourceLine[] =>
   parseAMLLLrc(normalizeLrcTimestampText(lyricText));
-const parseYrcText = (lyricText: string): ParsedSourceLine[] => parseAMLLYrc(lyricText);
+
+// The yrc slot is not always NCM YRC: some lyric sources deliver QRC or ESLrc
+// word-timed content through it. Running the YRC parser on those produces
+// empty/wordless lines, so pick the parser by detected format instead.
+const parseYrcText = (lyricText: string): ParsedSourceLine[] => {
+  switch (detectWordTimedLyricFormat(lyricText)) {
+    case "qrc":
+      return parseAMLLQrc(lyricText);
+    case "eslrc":
+      return parseAMLLEslrc(lyricText);
+    default:
+      return parseAMLLYrc(lyricText);
+  }
+};
 
 function finiteNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
@@ -292,6 +307,14 @@ export const parseLyricData = (data: RawLyricData | null): ParsedLyricResult => 
       result.yrcAMData = result.hasTTML
         ? yrcParsedRawLines
         : buildAMLLData(yrcParsedRawLines, effectiveYrcTranSource, effectiveYrcRomaSource);
+
+      // The yrc slot yielded no usable word-timed lines (unrecognized format or
+      // wordless content). Downgrade to line-timed lyrics so consumers fall back
+      // to the LRC data instead of reading empty word arrays.
+      if (!result.hasTTML && result.yrc.length === 0) {
+        result.hasYrc = false;
+        result.yrcAMData = [];
+      }
     }
   } catch {
     return createEmptyLyricResult();

--- a/src/utils/LyricsProcessor/parser/formatParser.ts
+++ b/src/utils/LyricsProcessor/parser/formatParser.ts
@@ -96,26 +96,110 @@ function resolveLineEnd(
   return endTime;
 }
 
-function resolveWordTime(
+interface ResolvedWordTime {
+  startTime: number;
+  endTime: number;
+}
+
+/**
+ * 判断一行的 words 是否携带可用的逐字时间轴。
+ * 至少存在一个正时长的 word，或存在两个不同的起始时间，才视为可用；
+ * 否则（全部缺失/全部相同起点且零时长）按退化数据处理。
+ */
+function hasUsableWordTiming(words: readonly TimedSourceWord[]): boolean {
+  let firstStart: number | undefined;
+  for (let i = 0; i < words.length; i++) {
+    const start = finiteTime(words[i].startTime);
+    const end = finiteTime(words[i].endTime);
+    if (start !== undefined && end !== undefined && end > start) return true;
+    if (start !== undefined) {
+      if (firstStart === undefined) {
+        firstStart = start;
+      } else if (start !== firstStart) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * 退化数据兜底：按可见字符数把行时长均匀分配给每个 word，
+ * 保证渲染端仍能得到递进的逐字时间，而不是整行同时高亮。
+ */
+function distributeWordTimesEvenly(
   words: readonly TimedSourceWord[],
-  index: number,
   lineStartTime: number,
   lineEndTime: number,
-) {
-  const word = words[index];
-  const startTime = finiteTime(word.startTime) ?? lineStartTime;
-  let endTime = finiteTime(word.endTime);
+): ResolvedWordTime[] {
+  const len = words.length;
+  const result: ResolvedWordTime[] = [];
+  result.length = len;
 
-  if (endTime === undefined || endTime <= startTime) {
-    const nextStart = finiteTime(words[index + 1]?.startTime);
-    endTime = nextStart !== undefined && nextStart > startTime ? nextStart : lineEndTime;
+  const weights: number[] = [];
+  weights.length = len;
+  let totalWeight = 0;
+  for (let i = 0; i < len; i++) {
+    const weight = (words[i].word ?? "").trim().length;
+    weights[i] = weight;
+    totalWeight += weight;
   }
 
-  if (endTime <= startTime) {
-    endTime = startTime + MIN_LINE_DURATION_MS;
+  const span = Math.max(0, lineEndTime - lineStartTime);
+  let cursor = lineStartTime;
+  for (let i = 0; i < len; i++) {
+    const weight = totalWeight > 0 ? weights[i] : 1;
+    const denominator = totalWeight > 0 ? totalWeight : len;
+    const duration = (span * weight) / denominator;
+    const endTime = i === len - 1 ? lineEndTime : cursor + duration;
+    result[i] = { startTime: cursor, endTime };
+    cursor = endTime;
   }
 
-  return { startTime, endTime };
+  return result;
+}
+
+/**
+ * 解析一行内全部 word 的起止时间。
+ * 时间缺失或非递增时，回退顺序为：下一个 word 的开始时间 →（末尾 word）行结束时间 → 零时长。
+ * 不再把中间 word 兜底到行结束时间——那会让多个 word 同时覆盖整行，
+ * 造成逐字歌词整行一起高亮。
+ */
+function resolveLineWordTimes(
+  words: readonly TimedSourceWord[],
+  lineStartTime: number,
+  lineEndTime: number,
+): ResolvedWordTime[] {
+  if (!hasUsableWordTiming(words)) {
+    return distributeWordTimesEvenly(words, lineStartTime, lineEndTime);
+  }
+
+  const len = words.length;
+  const result: ResolvedWordTime[] = [];
+  result.length = len;
+
+  let prevEnd = lineStartTime;
+  for (let i = 0; i < len; i++) {
+    const word = words[i];
+    const startTime = finiteTime(word.startTime) ?? prevEnd;
+    let endTime = finiteTime(word.endTime);
+
+    if (endTime === undefined || endTime <= startTime) {
+      const nextStart = finiteTime(words[i + 1]?.startTime);
+      if (nextStart !== undefined && nextStart > startTime) {
+        endTime = nextStart;
+      } else if (i === len - 1 && lineEndTime > startTime) {
+        endTime = lineEndTime;
+      } else {
+        endTime = startTime;
+      }
+    }
+
+    result[i] = { startTime, endTime };
+    prevEnd = endTime;
+  }
+
+  return result;
 }
 
 /**
@@ -228,6 +312,7 @@ export const parseYrcLines = (yrcData: LyricLine[]): ParsedYrcLine[] => {
     const lineEndTime = resolveLineEnd(yrcData, i, lineStartTime, false);
     const time = msToS(lineStartTime);
     const endTime = msToS(lineEndTime);
+    const wordTimes = resolveLineWordTimes(words, lineStartTime, lineEndTime);
 
     // Build content array and string in one pass
     const content: ParsedYrcLine["content"] = [];
@@ -236,7 +321,7 @@ export const parseYrcLines = (yrcData: LyricLine[]): ParsedYrcLine[] => {
 
     for (let j = 0; j < wordsLen; j++) {
       const word = words[j];
-      const wordTime = resolveWordTime(words, j, lineStartTime, lineEndTime);
+      const wordTime = wordTimes[j];
       const wordText = word.word;
       // Preserve original word text including trailing spaces.
       // TTML lyrics rely on trailing spaces to separate words;
@@ -458,8 +543,11 @@ export const buildAMLLData = (
     const wordsLen = words.length;
 
     const firstWord = wordsLen > 0 ? words[0] : null;
-    const startTime = firstWord ? firstWord.startTime : resolveLineStart(line);
+    const startTime = firstWord
+      ? (finiteTime(firstWord.startTime) ?? resolveLineStart(line))
+      : resolveLineStart(line);
     const endTime = resolveLineEnd(lrcData, i, startTime, true);
+    const wordTimes = resolveLineWordTimes(words, startTime, endTime);
 
     // Build words array efficiently
     const resultWords: AMLLLine["words"] = [];
@@ -467,7 +555,7 @@ export const buildAMLLData = (
 
     for (let j = 0; j < wordsLen; j++) {
       const w = words[j];
-      const wordTime = resolveWordTime(words, j, startTime, endTime);
+      const wordTime = wordTimes[j];
       resultWords[j] = {
         word: w.word,
         startTime: wordTime.startTime,
@@ -532,6 +620,7 @@ export function convertToAMLL(lines: InputLyricLine[]): AMLLLine[] {
     const wordsLen = sourceWords.length;
     const startTime = resolveLineStart(l);
     const endTime = resolveLineEnd(lines, i, startTime, false);
+    const wordTimes = resolveLineWordTimes(sourceWords, startTime, endTime);
 
     // Build words array
     const words: AMLLLine["words"] = [];
@@ -539,7 +628,7 @@ export function convertToAMLL(lines: InputLyricLine[]): AMLLLine[] {
 
     for (let j = 0; j < wordsLen; j++) {
       const w = sourceWords[j];
-      const wordTime = resolveWordTime(sourceWords, j, startTime, endTime);
+      const wordTime = wordTimes[j];
       words[j] = {
         startTime: wordTime.startTime,
         endTime: wordTime.endTime,

--- a/src/utils/LyricsProcessor/service.ts
+++ b/src/utils/LyricsProcessor/service.ts
@@ -4,10 +4,10 @@
  */
 
 import request from "@/utils/request";
-import { parseQrc, parseTTML, parseYrc } from "@applemusic-like-lyrics/lyric";
+import { parseEslrc, parseQrc, parseTTML, parseYrc } from "@applemusic-like-lyrics/lyric";
 import type { TTMLLyric } from "@applemusic-like-lyrics/lyric";
 import {
-  detectYrcType,
+  detectWordTimedLyricFormat,
   detectLrcTimestampMode,
   formatLrcTime,
   parseFirstLrcTimestamp,
@@ -330,21 +330,22 @@ export class LyricService {
             );
 
             try {
-              // 判断内容是否是yrc或qrc格式，并选择对应的解析器
+              // 判断内容是yrc、qrc还是eslrc格式，并选择对应的解析器
               let parsedLyric;
 
               // 使用内容检测歌词类型
               const content = result.yrc.lyric;
-              const contentType = detectYrcType(content);
+              const contentType = detectWordTimedLyricFormat(content) ?? "yrc";
 
-              if (contentType === "yrc") {
-                // 使用YRC解析器
-                parsedLyric = parseYrc(content);
-                console.log(`[LyricService] Using YRC parser for id: ${id}`);
-              } else {
-                // 使用QRC解析器
+              if (contentType === "qrc") {
                 parsedLyric = parseQrc(content);
                 console.log(`[LyricService] Using QRC parser for id: ${id}`);
+              } else if (contentType === "eslrc") {
+                parsedLyric = parseEslrc(content);
+                console.log(`[LyricService] Using ESLrc parser for id: ${id}`);
+              } else {
+                parsedLyric = parseYrc(content);
+                console.log(`[LyricService] Using YRC parser for id: ${id}`);
               }
 
               if (parsedLyric && parsedLyric.length > 0) {

--- a/src/utils/LyricsProcessor/timeUtils.ts
+++ b/src/utils/LyricsProcessor/timeUtils.ts
@@ -222,19 +222,41 @@ export function formatLrcTime(timeMs: number): string {
   return `${min < 10 ? "0" : ""}${min}:${sec < 10 ? "0" : ""}${sec}.${cs < 10 ? "0" : ""}${cs}`;
 }
 
+export type WordTimedLyricFormat = "yrc" | "qrc" | "eslrc";
+
+// [lineStartMs,lineDurationMs] line header used by both YRC and QRC
+const WORD_TIMED_LINE_HEADER_REGEX = /^\[\d+,\d+\]/m;
+// YRC word token: (startMs,durationMs,0)
+const YRC_WORD_TOKEN_REGEX = /\(\d+,\d+,\d+\)/;
+// QRC / Lyricify Syllable word token: (startMs,durationMs)
+const QRC_WORD_TOKEN_REGEX = /\(\d+,\d+\)/;
+// ESLrc places [mm:ss.xx] timestamps directly after word text
+const ESLRC_INLINE_TIMESTAMP_REGEX = /[^\s[\]]\[\d{1,3}:\d{1,2}(?:\.\d{1,3})?\]/;
+
+/**
+ * 检测逐字歌词文本的具体格式
+ * @param content 歌词内容
+ * @returns 'yrc' | 'qrc' | 'eslrc'，无法识别为逐字格式时返回 null
+ */
+export function detectWordTimedLyricFormat(content: string): WordTimedLyricFormat | null {
+  if (!content) return null;
+
+  if (WORD_TIMED_LINE_HEADER_REGEX.test(content)) {
+    // 3-field tokens are YRC; check first because a QRC-style 2-field token
+    // never appears inside a 3-field token text.
+    if (YRC_WORD_TOKEN_REGEX.test(content)) return "yrc";
+    if (QRC_WORD_TOKEN_REGEX.test(content)) return "qrc";
+    return null;
+  }
+
+  return ESLRC_INLINE_TIMESTAMP_REGEX.test(content) ? "eslrc" : null;
+}
+
 /**
  * 检测 YRC/QRC 格式类型
  * @param content 歌词内容
  * @returns 'yrc' 或 'qrc'
  */
 export function detectYrcType(content: string): "yrc" | "qrc" {
-  // Check for YRC markers first (more specific)
-  if (content.includes("[x-trans") || content.includes("[merge]")) {
-    return "yrc";
-  }
-  // QRC uses < > delimiters with comma-separated values
-  if (content.indexOf("<") !== -1 && content.indexOf(",") !== -1 && content.indexOf(">") !== -1) {
-    return "qrc";
-  }
-  return "qrc";
+  return detectWordTimedLyricFormat(content) === "qrc" ? "qrc" : "yrc";
 }


### PR DESCRIPTION
Word-level timestamps could collapse to the full line span, making the AMLL LyricPlayer highlight every word of a word-timed line at once:

- resolveWordTime fell back to lineEndTime for any word whose endTime was missing or non-increasing, so multiple broken words all spanned lineStart..lineEnd. Replace it with resolveLineWordTimes: fall back to the next word start, only let the last word extend to line end, and drop the 800ms line-duration clamp that was misapplied to words.
- Lines whose words carry no usable timing at all (all-zero or identical timestamps) now distribute the line duration across words weighted by visible characters, keeping a progressive karaoke sweep.
- The yrc slot is not always NCM YRC: detect QRC and ESLrc payloads and parse them with the matching AMLL parser instead of feeding them to parseYrc, which produced empty or wordless lines.
- detectYrcType classified standard YRC as QRC (it only recognized [x-trans]/[merge] markers); reimplement it on top of the new token-based detectWordTimedLyricFormat.
- When the yrc slot still yields no usable word-timed lines, clear hasYrc/yrcAMData so lyric index sync and the player fall back to the LRC data instead of reading empty word arrays.