### PR TITLE
fix(Tauri/macOS): 修复 macOS 无法打开应用程序的问题

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -167,6 +167,46 @@ jobs:
         run: |
           pnpm build
 
+      # macOS 签名与公证（可选）。仅当仓库配置了对应 Secrets 时才导出环境变量：
+      # - APPLE_CERTIFICATE / APPLE_CERTIFICATE_PASSWORD / APPLE_SIGNING_IDENTITY 三者齐全时启用 Developer ID 签名
+      #   （APPLE_SIGNING_IDENTITY 会覆盖 tauri.macos.conf.json 中的 ad-hoc "-" 签名）
+      # - APPLE_ID / APPLE_PASSWORD / APPLE_TEAM_ID 三者齐全时额外启用公证 (notarization)
+      # 未配置时回退到 tauri.macos.conf.json 的 ad-hoc 签名，
+      # 用户首次打开需清除 quarantine（见 Release 说明）。
+      - name: "macOS: 配置 Apple 签名与公证（可选）"
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set_env() {
+            local name="$1" value="$2"
+            {
+              echo "${name}<<__GMPLAYER_SECRET_EOF__"
+              echo "$value"
+              echo "__GMPLAYER_SECRET_EOF__"
+            } >> "$GITHUB_ENV"
+          }
+          if [[ -n "$APPLE_CERTIFICATE" && -n "$APPLE_CERTIFICATE_PASSWORD" && -n "$APPLE_SIGNING_IDENTITY" ]]; then
+            set_env APPLE_CERTIFICATE "$APPLE_CERTIFICATE"
+            set_env APPLE_CERTIFICATE_PASSWORD "$APPLE_CERTIFICATE_PASSWORD"
+            set_env APPLE_SIGNING_IDENTITY "$APPLE_SIGNING_IDENTITY"
+            echo "已启用 Apple Developer ID 签名"
+          else
+            echo "未配置 Apple 签名 Secrets，使用 ad-hoc 签名"
+          fi
+          if [[ -n "$APPLE_ID" && -n "$APPLE_PASSWORD" && -n "$APPLE_TEAM_ID" ]]; then
+            set_env APPLE_ID "$APPLE_ID"
+            set_env APPLE_PASSWORD "$APPLE_PASSWORD"
+            set_env APPLE_TEAM_ID "$APPLE_TEAM_ID"
+            echo "已启用 Apple 公证 (notarization)"
+          fi
+
       - name: 构建 Player 程序并发布自动构建
         uses: tauri-apps/tauri-action@v0
         with:
@@ -179,6 +219,12 @@ jobs:
             最新 ${{ github.ref_name }} 分支开发调试构建。
             Development version may be unstable and may not work properly, please only for test purpose.
             开发版本可能不稳定且可能无法正常工作，请仅用于测试目的。
+
+            macOS: builds are not notarized by Apple yet. If macOS says the app "is damaged and can't be opened" / "无法打开", run:
+            macOS: 构建暂未经过 Apple 公证。如果 macOS 提示"已损坏，无法打开"或"无法打开应用程序"，请在终端执行：
+            `xattr -cr /Applications/GMPlayer.app`
+            Then open the app again. (macOS 15+: you may also need System Settings → Privacy & Security → Open Anyway)
+            然后重新打开应用。（macOS 15 及以上还可在 系统设置 → 隐私与安全性 → 仍要打开 中放行）
 
             Latest commits (最新提交): ${{ github.event.head_commit.message }}
           prerelease: true

--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ pnpm dev
 对于其他 Coding Agents，也可以进行一样的适配操作
 这里为精简项目根目录，故不进行配置，也请勿提交，可在本地自行进行软链接。
 
+### macOS 无法打开应用（"已损坏"提示）
+
+Tauri macOS 构建目前仅使用 ad-hoc 签名，未经过 Apple 公证。从 GitHub Releases 下载的 `.dmg` / `.app` 会被 macOS 附加 quarantine 属性，首次打开时 Gatekeeper 会提示 **"GMPlayer 已损坏，无法打开"** 或 **"无法打开应用程序"**。这不是应用本身损坏，清除 quarantine 属性即可正常打开：
+
+```bash
+xattr -cr /Applications/GMPlayer.app
+```
+
+若将 App 放在其他位置，请把路径替换为实际位置。macOS 15 (Sequoia) 及以上也可以在首次被拦截后，前往 `系统设置 → 隐私与安全性`，在页面底部点击 `仍要打开`。
+
+维护者如需彻底去除该提示，可在仓库配置以下 GitHub Secrets 启用 Developer ID 签名与公证（CI 会自动生效）：`APPLE_CERTIFICATE`、`APPLE_CERTIFICATE_PASSWORD`、`APPLE_SIGNING_IDENTITY`，以及可选的 `APPLE_ID`、`APPLE_PASSWORD`、`APPLE_TEAM_ID`。
+
 ### Linux Wayland 图形兼容
 
 Tauri Linux 端使用 WebKitGTK。部分 Wayland 组合器、显卡驱动或混合显卡环境下，WebKitGTK 的 DMABUF renderer 可能导致 WebGL/Canvas 加速异常、黑屏或渲染卡顿。应用默认会在 Wayland 会话下启用较保守的 WebKitGTK 图形策略；如需排查，可通过启动环境变量覆盖：

--- a/src-tauri/src/desktop/mod.rs
+++ b/src-tauri/src/desktop/mod.rs
@@ -166,7 +166,16 @@ pub fn run() {
                 warn!("Failed to pre-create tray popup: {}", e);
             }
 
-            spawn_audio_preheat(app_handle);
+            spawn_audio_preheat(app_handle.clone());
+
+            // Never leave the app running invisibly: if the frontend fails
+            // before revealing the hidden main window, force-show it.
+            let _ = std::thread::Builder::new()
+                .name("main-window-reveal-fallback".into())
+                .spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_secs(10));
+                    wm::reveal_main_window_if_stuck(&app_handle);
+                });
 
             Ok(())
         })

--- a/src-tauri/src/desktop/window/manager.rs
+++ b/src-tauri/src/desktop/window/manager.rs
@@ -259,6 +259,31 @@ pub fn set_main_window_effect_theme(app: &AppHandle, dark: bool) -> Result<(), S
     Ok(())
 }
 
+/// Safety net for the hidden main window. The window is created invisible and
+/// only revealed when the frontend calls `set_main_window_effect_theme`; if the
+/// frontend fails before that call (script error, rejected invoke), the app
+/// would keep running with no window at all — on macOS this looks like the app
+/// "cannot be opened". Apply the default material for the current system theme
+/// and reveal instead of staying invisible.
+pub fn reveal_main_window_if_stuck(app: &AppHandle) {
+    if MAIN_SHELL_EFFECT_INITIALIZED.load(Ordering::Acquire) {
+        return;
+    }
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+    if window.is_visible().unwrap_or(false) {
+        return;
+    }
+    let dark = matches!(window.theme(), Ok(tauri::Theme::Dark));
+    log::warn!("Main window was never revealed by the frontend; forcing fallback reveal");
+    if let Err(e) = set_main_window_effect_theme(app, dark) {
+        log::warn!("Fallback reveal failed to apply the shell material: {e}");
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
 fn apply_runtime_size_constraints(
     window: &WebviewWindow,
     config: &WindowConfig,

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -11,6 +11,7 @@
       "bundleName": "GMPlayer",
       "minimumSystemVersion": "10.15",
       "hardenedRuntime": true,
+      "signingIdentity": "-",
       "dmg": {
         "windowSize": {
           "width": 660,


### PR DESCRIPTION
macOS 产物此前完全未签名（x64 交叉编译产物无任何签名，arm64 仅有
链接器 ad-hoc 签名且 bundle 未封印），从 GitHub Releases 下载后被
Gatekeeper 拦截为"已损坏，无法打开"。

- tauri.macos.conf.json: 显式声明 signingIdentity "-"，让 bundler 对整个 .app（含跨架构产物）进行 ad-hoc 签名并封印资源
- CI: 新增可选的 Apple Developer ID 签名与公证步骤，配置对应 Secrets 后自动启用（APPLE_SIGNING_IDENTITY 环境变量覆盖 ad-hoc）； 未配置时保持 ad-hoc 回退，Release 说明附带 quarantine 清除指引
- README: 增加 macOS "已损坏/无法打开" 的用户解决方案说明
- desktop: 主窗口隐藏创建后，若前端 reveal 链路失败（脚本错误或 invoke 被拒），10 秒后应用默认材质并强制显示窗口，避免应用启动 后永远不可见