### PR TITLE
fix(Player): 封面/唱片视图垂直居中修复与唱片光学居中

### DIFF
--- a/src/components/Player/PlayerCover.vue
+++ b/src/components/Player/PlayerCover.vue
@@ -385,22 +385,22 @@ onMounted(() => {
 
 <style lang="scss" scoped>
 .player-cover-container {
-  /* 高度预算：控件区约 15rem + 纵向 gap 2rem + 顶部关闭手柄余量 2.5rem */
+  /* 高度预算：控件区约 15rem + 纵向 gap 2rem + 上下对称 padding 各 2.5rem */
   --cover-controls-budget: 19.5rem;
-  --cover-size: max(10rem, min(50vh, 38vw, calc(100vh - var(--cover-controls-budget) - 2.5rem)));
+  --cover-size: max(10rem, min(50vh, 38vw, calc(100vh - var(--cover-controls-budget) - 5rem)));
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 2rem;
-  /* 关闭手柄绝对定位在封面上方出画区，这里预留其高度，
-     避免矮窗口下被居中布局顶出视口 */
-  padding-top: 2.5rem;
+  /* 顶部为绝对定位的关闭手柄保留出画余量（矮窗口不被居中布局顶出视口）；
+     底部等量 padding 保持视觉中心对称 */
+  padding: 2.5rem 0;
 
   @media screen and (max-height: 768px) {
-    --cover-size: max(9rem, min(45vh, 38vw, calc(100vh - var(--cover-controls-budget) - 2rem)));
+    --cover-size: max(9rem, min(45vh, 38vw, calc(100vh - var(--cover-controls-budget) - 4.5rem)));
     gap: 1.5rem;
-    padding-top: 2.25rem;
+    padding: 2.25rem 0;
   }
 
   .cover-stage {

--- a/src/components/Player/PlayerRecord.vue
+++ b/src/components/Player/PlayerRecord.vue
@@ -294,12 +294,12 @@ const closeBigPlayer = () => {
 
 <style lang="scss" scoped>
 .record {
-  /* 高度预算：控件区约 15rem + 纵向 gap 2rem + 顶部关闭手柄余量 2.5rem；
+  /* 高度预算：控件区约 15rem + 纵向 gap 2rem + 上下对称 padding 各 2.5rem；
      stage 高为封面的 1.25 倍，故预算需除以 1.25 */
   --cover-controls-budget: 19.5rem;
   --cover-size: max(
     10rem,
-    min(50vh, 38vw, calc((100vh - var(--cover-controls-budget) - 2.5rem) / 1.25))
+    min(50vh, 38vw, calc((100vh - var(--cover-controls-budget) - 5rem) / 1.25))
   );
   position: relative;
   width: 100%;
@@ -307,16 +307,17 @@ const closeBigPlayer = () => {
   flex-direction: column;
   align-items: center;
   gap: 2rem;
-  /* 为绝对定位的关闭手柄保留出画余量，避免矮窗口下被居中布局顶出视口 */
-  padding-top: 2.5rem;
+  /* 顶部为绝对定位的关闭手柄保留出画余量（矮窗口不被居中布局顶出视口）；
+     底部等量 padding 保持视觉中心对称 */
+  padding: 2.5rem 0;
 
   @media screen and (max-height: 768px) {
     --cover-size: max(
       9rem,
-      min(45vh, 38vw, calc((100vh - var(--cover-controls-budget) - 2rem) / 1.25))
+      min(45vh, 38vw, calc((100vh - var(--cover-controls-budget) - 4.5rem) / 1.25))
     );
     gap: 1.5rem;
-    padding-top: 2.25rem;
+    padding: 2.25rem 0;
   }
   &:hover {
     .control {

--- a/src/components/Player/PlayerRecord.vue
+++ b/src/components/Player/PlayerRecord.vue
@@ -299,7 +299,7 @@ const closeBigPlayer = () => {
   --cover-controls-budget: 19.5rem;
   --cover-size: max(
     10rem,
-    min(50vh, 38vw, calc((100vh - var(--cover-controls-budget) - 5rem) / 1.25))
+    min(50vh, 38vw, calc((100vh - var(--cover-controls-budget) - 5rem) / 1.18))
   );
   position: relative;
   width: 100%;
@@ -308,16 +308,17 @@ const closeBigPlayer = () => {
   align-items: center;
   gap: 2rem;
   /* 顶部为绝对定位的关闭手柄保留出画余量（矮窗口不被居中布局顶出视口）；
-     底部等量 padding 保持视觉中心对称 */
-  padding: 2.5rem 0;
+     底部 padding 额外偏置 0.06×封面：唱臂预留区视觉上偏空，
+     纯几何居中会显得整体偏下，此处做光学居中（预算中 1.18 = 1.12 + 0.06） */
+  padding: 2.5rem 0 calc(2.5rem + var(--cover-size) * 0.06);
 
   @media screen and (max-height: 768px) {
     --cover-size: max(
       9rem,
-      min(45vh, 38vw, calc((100vh - var(--cover-controls-budget) - 4.5rem) / 1.25))
+      min(45vh, 38vw, calc((100vh - var(--cover-controls-budget) - 4.5rem) / 1.18))
     );
     gap: 1.5rem;
-    padding: 2.25rem 0;
+    padding: 2.25rem 0 calc(2.25rem + var(--cover-size) * 0.06);
   }
   &:hover {
     .control {
@@ -327,7 +328,9 @@ const closeBigPlayer = () => {
   .record-stage {
     position: relative;
     width: min(var(--cover-size), 100%);
-    aspect-ratio: 4 / 5;
+    /* 1.12 倍高：压缩唱臂预留区，唱臂与盘面重叠更贴近真实唱机，
+       同时减少顶部视觉空腔 */
+    aspect-ratio: 1 / 1.12;
     display: grid;
     place-items: end center;
 


### PR DESCRIPTION
## Summary

PR #8 的两个后续修复，解决 BigPlayer 封面/唱片视图的视觉居中问题：

- **封面/唱片视图恢复垂直居中**：#8 中为关闭手柄预留的单侧 `padding-top` 会让 flex 居中的内容整体下沉半个 padding。改为上下对称 padding——顶部余量语义不变（矮窗口下手柄仍有保底出画空间），底部等量 padding 恢复视觉中心；`--cover-size` 高度预算同步扣除两侧 padding。
- **唱片视图光学居中**：唱臂预留区（stage 顶部区域）视觉上大半是留白，纯几何居中会让唱片+控件的视觉主体下坠约 50px。将 stage 比例从 1.25 收紧到 1.12（唱臂与盘面重叠更贴近真实唱机形态），并以 `0.06 × 封面尺寸` 的底部 padding 偏置做光学居中，高度预算按 1.18 折算。

## Affected platforms

Web / Tauri 桌面（BigPlayer 封面与唱片两种播放器样式）；移动端布局不受影响。

## Validation

- `pnpm fmt:check` / `pnpm lint` / `pnpm build` 全部通过
- Playwright 实测（cover / record × 1440×900 / 1000×540）：
  - cover 模式上下留白 80/80、62/62（px），完全对称
  - record 模式几何盒上偏 26px，视觉主体（唱片+控件）中心距视口中心约 13px
  - 关闭手柄在全部尺寸下位于视口内（top 25–52px）

## Linked issues

Follow-up to #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM6Z3CNFAXwMuicUNy461v

---
_Generated by [Claude Code](https://claude.ai/code/session_01XM6Z3CNFAXwMuicUNy461v)_