### PR TITLE
perf(UI): 剩余大列表全部启用虚拟滚动

### DIFF
--- a/src/views/Artist/all-songs.vue
+++ b/src/views/Artist/all-songs.vue
@@ -14,7 +14,13 @@
         </div>
       </div>
       <div class="song-panel">
-        <DataLists :listData="artistData" />
+        <DataLists
+          :listData="artistData"
+          virtual
+          virtual-height="min(68vh, 760px)"
+          :virtual-item-size="54"
+          :virtual-threshold="40"
+        />
       </div>
       <Pagination
         v-if="artistData[0]"

--- a/src/views/History/HistoryView.vue
+++ b/src/views/History/HistoryView.vue
@@ -17,7 +17,13 @@
         </div>
       </div>
       <div class="song-panel">
-        <DataLists :listData="music.getPlayHistory" />
+        <DataLists
+          :listData="music.getPlayHistory"
+          virtual
+          virtual-height="min(68vh, 760px)"
+          :virtual-item-size="54"
+          :virtual-threshold="40"
+        />
       </div>
     </template>
     <div class="empty-state" v-else>

--- a/src/views/Search/songs.vue
+++ b/src/views/Search/songs.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="songs">
     <div class="song-panel">
-      <DataLists :listData="searchData" :loading="loading" />
+      <DataLists :listData="searchData" :loading="loading" virtual />
     </div>
     <Pagination
       v-if="searchData[0]"

--- a/src/views/User/cloud.vue
+++ b/src/views/User/cloud.vue
@@ -38,7 +38,7 @@
         <span>{{ cloudSpace[1] }} G</span>
       </div>
     </div>
-    <DataLists :listData="cloudData" />
+    <DataLists :listData="cloudData" virtual />
     <Pagination
       :totalCount="totalCount"
       :pageNumber="pageNumber"


### PR DESCRIPTION
## Summary

将剩余未虚拟化的大数据列表全部接入 `n-virtual-list`（`DataLists` 已有的 `virtual` 开关，Sidebar / QueuePanel / BigPlayer 队列 / PlayList / Album / DailySongs 此前已使用）：

- **播放历史**、**歌手全部歌曲**：斑马纹列表启用虚拟滚动，参数与 PlayList/Album 对齐（`virtual-item-size=54`、`virtual-threshold=40`、`virtual-height=min(68vh, 760px)`）
- **搜索歌曲**、**云盘**：启用默认参数虚拟化（默认卡片行高 94px、阈值 60），配合现有分页兜底

至此所有斑马纹多行数据展示均为虚拟列表渲染。

## Affected platforms

Web / Tauri 桌面与移动端（History / Artist all-songs / Search songs / User cloud 四个页面）。

## Validation

- `pnpm fmt:check` / `pnpm lint` / `pnpm build` 全部通过
- Playwright 实测播放历史页注入 100 条记录：虚拟容器生效，DOM 仅渲染 14 行，斑马纹与首尾行圆角正常

## Linked issues

Follow-up to #8 / #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM6Z3CNFAXwMuicUNy461v

---
_Generated by [Claude Code](https://claude.ai/code/session_01XM6Z3CNFAXwMuicUNy461v)_