### PR TITLE
perf(AudioBackend): trim dead work from analysis, mixer and IPC hot p…

### DIFF
--- a/src-tauri/crates/audio-analysis/src/lib.rs
+++ b/src-tauri/crates/audio-analysis/src/lib.rs
@@ -204,8 +204,27 @@ impl FftProcessor {
     /// `delta_ms` is wall-clock time since last call (from performance.now()).
     /// Returns reference to the normalized spectrum (0-255).
     pub fn read_spectrum(&mut self, _delta_ms: f32) -> &[f32] {
+        if self.run_fft_frame() {
+            self._normalize_and_smooth();
+        }
+        &self.spectrum
+    }
+
+    /// Raw-only variant of `read_spectrum` for the native IPC path: refreshes
+    /// `frame_buf`/`result_buf` (and thus `raw_spectrum()` / `get_raw_bins`)
+    /// without computing the WASM-only normalized `spectrum()` output.
+    /// Returns `true` when a new FFT frame was produced.
+    pub fn read_spectrum_raw(&mut self) -> bool {
+        self.run_fft_frame()
+    }
+
+    /// Shared per-frame FFT pipeline: Hamming window → FFT → magnitudes →
+    /// frequency sampling into `frame_buf` → raw-frame smoothing into
+    /// `result_buf`. Returns `false` (computing nothing) when fewer than
+    /// `FFT_SIZE` samples are buffered.
+    fn run_fft_frame(&mut self) -> bool {
         if self.available_samples < FFT_SIZE {
-            return &self.spectrum;
+            return false;
         }
 
         self.refresh_sample_map();
@@ -225,11 +244,8 @@ impl FftProcessor {
 
         self.sample_magnitudes_into_frame();
         self.smooth_raw_frame();
-
-        self._normalize_and_smooth();
         self.raw_bins_dirty = true;
-
-        &self.spectrum
+        true
     }
 
     /// Uniformly resample `spec` into a 2048-element freq buffer.
@@ -647,6 +663,20 @@ impl AudioProcessor {
             output_spectrum[..len].copy_from_slice(&spec[..len]);
         }
 
+        self.analyze_low_freq(delta_ms)
+    }
+
+    /// Raw pipeline for the native IPC path: FFT → raw bins → lowFreq analysis.
+    ///
+    /// Skips the WASM-only 0-255 normalization/EMA pass and the spectrum copy —
+    /// native consumers read `fft.raw_spectrum()` and the returned lowFreq value,
+    /// both of which are bit-identical to what `process_frame` produces.
+    pub fn process_frame_raw(&mut self, delta_ms: f32) -> f32 {
+        self.fft.read_spectrum_raw();
+        self.analyze_low_freq(delta_ms)
+    }
+
+    fn analyze_low_freq(&mut self, delta_ms: f32) -> f32 {
         let fft = &mut self.fft;
         let analyzer = &mut self.analyzer;
         let bin_count = analyzer.config().bin_count;
@@ -902,6 +932,60 @@ mod tests {
             "lowFreq {} out of [0, 1]",
             low_freq
         );
+    }
+
+    #[test]
+    fn test_process_frame_raw_matches_full_pipeline_native_outputs() {
+        // The native IPC path consumes only raw_spectrum(), get_raw_bins() and
+        // the returned lowFreq value. process_frame_raw must keep those
+        // bit-identical to process_frame while skipping the WASM-only
+        // normalization work.
+        let mut full = AudioProcessor::new(2048, 80.0, 2000.0, 2, 10, 0.35, 0.003);
+        let mut raw = AudioProcessor::new(2048, 80.0, 2000.0, 2, 10, 0.35, 0.003);
+        full.clear();
+        raw.clear();
+
+        let rate = 44100.0;
+        let mut scratch = vec![0.0f32; 2048];
+        for step in 0..12 {
+            let freq = 110.0 * (1 + step % 5) as f32;
+            let amp = 0.2 + 0.6 * ((step % 3) as f32 / 2.0);
+            let tone: Vec<f32> = (0..FFT_SIZE)
+                .map(|i| amp * (TAU * freq * i as f32 / rate).sin())
+                .collect();
+            full.push_pcm(&tone, 44100);
+            raw.push_pcm(&tone, 44100);
+
+            let low_full = full.process_frame(16.0, &mut scratch);
+            let low_raw = raw.process_frame_raw(16.0);
+
+            assert_eq!(low_full, low_raw, "lowFreq diverged at step {step}");
+            assert_eq!(
+                full.fft.raw_spectrum(),
+                raw.fft.raw_spectrum(),
+                "raw_spectrum diverged at step {step}"
+            );
+        }
+
+        assert_eq!(full.fft.get_raw_bins(2), raw.fft.get_raw_bins(2));
+        assert_eq!(full.fft.get_raw_bins(4), raw.fft.get_raw_bins(4));
+    }
+
+    #[test]
+    fn test_read_spectrum_raw_reports_frame_availability() {
+        let mut proc = FftProcessor::new(FftConfig::default());
+        assert!(!proc.read_spectrum_raw(), "no PCM buffered yet");
+
+        let rate = 44100.0;
+        let samples: Vec<f32> = (0..FFT_SIZE)
+            .map(|i| (TAU * 440.0 * i as f32 / rate).sin())
+            .collect();
+        proc.push_pcm(&samples, 44100);
+        assert!(proc.read_spectrum_raw());
+        assert!(proc.raw_spectrum().iter().any(|&v| v > 0.0));
+        // The WASM-only normalized spectrum must stay untouched on the raw path.
+        assert!(proc.spectrum().iter().all(|&v| v == 0.0));
+        assert!((proc.peak_value - 0.0001).abs() < 1e-8);
     }
 
     #[test]

--- a/src-tauri/crates/audio-backend/src/analysis.rs
+++ b/src-tauri/crates/audio-backend/src/analysis.rs
@@ -101,10 +101,6 @@ fn analysis_loop(
         cfg.smoothing_factor,
     );
 
-    // `spectrum` is only a scratch buffer for the processor's normalized WASM
-    // compatibility path. Native IPC emits raw FFT magnitudes from
-    // `proc.fft.raw_spectrum()`, matching AMLL's fftDataAtom data flow.
-    let mut spectrum = vec![0.0f32; 2048];
     let mut last_analysis = Instant::now();
     let mut last_fft_emit = Instant::now() - FFT_EMIT_INTERVAL;
     let mut pending_mono_samples = 0usize;
@@ -147,7 +143,11 @@ fn analysis_loop(
         {
             let now = Instant::now();
             let delta_ms = now.duration_since(last_analysis).as_secs_f32() * 1000.0;
-            let low_freq = proc.process_frame(delta_ms, &mut spectrum);
+            // Native IPC emits raw FFT magnitudes from `proc.fft.raw_spectrum()`
+            // (matching AMLL's fftDataAtom data flow), so run the raw pipeline:
+            // it skips the WASM-only 0-255 normalization/EMA pass whose output
+            // nothing on this path ever reads.
+            let low_freq = proc.process_frame_raw(delta_ms);
 
             let drained = ((delta_ms / 1000.0) * current_sample_rate.max(1) as f32) as usize;
             pending_mono_samples = pending_mono_samples.saturating_sub(drained.max(1));

--- a/src-tauri/crates/audio-backend/src/automix/mod.rs
+++ b/src-tauri/crates/audio-backend/src/automix/mod.rs
@@ -234,14 +234,42 @@ use vocal::analyze_vocal_activity;
 
 // ─── Main Analysis Entry Point ─────────────────────────────────────
 
+/// Cap for the duration-hint preallocation (in mono samples): 64M samples
+/// ≈ 256 MiB of f32, covering ~24 min @ 44.1 kHz or ~11 min @ 96 kHz. A
+/// corrupt container header claiming hours must not translate into a giant
+/// blind allocation — tracks longer than the cap simply fall back to doubling
+/// growth beyond it, which is never worse than the old un-hinted behavior.
+const MONO_PREALLOC_MAX_SAMPLES: usize = 64 << 20;
+
+/// Mono-sample capacity estimate from the container duration hint, with a
+/// small headroom margin (~1.6% + 1024) so hints that undershoot slightly do
+/// not push the buffer into a full doubling reallocation for the excess.
+fn mono_capacity_hint(duration_hint: Option<f32>, sample_rate: u32) -> usize {
+    let Some(duration) = duration_hint.filter(|d| d.is_finite() && *d > 0.0) else {
+        return 0;
+    };
+    let frames = (duration as f64 * sample_rate as f64).ceil() as usize;
+    (frames + frames / 64 + 1024).min(MONO_PREALLOC_MAX_SAMPLES)
+}
+
 fn decode_audio_to_mono(audio_data: Vec<u8>) -> Result<(Vec<f32>, u32, f32), String> {
-    let cursor = Cursor::new(audio_data);
-    let decoder = Decoder::new(cursor).map_err(|e| format!("decode audio: {e}"))?;
+    decode_source_to_mono(Cursor::new(audio_data))
+}
+
+fn decode_source_to_mono<R>(input: R) -> Result<(Vec<f32>, u32, f32), String>
+where
+    R: std::io::Read + std::io::Seek + Send + Sync + 'static,
+{
+    let decoder = Decoder::new(input).map_err(|e| format!("decode audio: {e}"))?;
     let channels = decoder.channels().get() as usize;
     let sample_rate = decoder.sample_rate().get();
     let duration_hint = decoder.total_duration().map(|d| d.as_secs_f32());
 
-    let mut mono = Vec::new();
+    // Preallocate from the duration hint: growing a multi-minute track by
+    // push-doubling briefly holds the old and new buffers at every doubling
+    // (up to ~3× the final size at the last one), which alone accounted for
+    // most of the transient RES spike during AutoMix prepare.
+    let mut mono = Vec::with_capacity(mono_capacity_hint(duration_hint, sample_rate));
     let mut frame_sum = 0.0f32;
     let mut frame_channel = 0usize;
 
@@ -396,8 +424,12 @@ pub fn analyze_audio_file(
     path: impl AsRef<Path>,
     analyze_bpm: bool,
 ) -> Result<TrackAnalysis, String> {
-    let audio_data = std::fs::read(path.as_ref()).map_err(|e| format!("read audio source: {e}"))?;
-    let (samples, sample_rate, duration) = decode_audio_to_mono(audio_data)?;
+    // Stream the compressed file from disk instead of fs::read-ing it whole:
+    // the encoded bytes would otherwise stay resident (owned by the decoder's
+    // Cursor) for the entire full-track decode, adding the whole file size on
+    // top of the PCM buffer at the peak.
+    let file = std::fs::File::open(path.as_ref()).map_err(|e| format!("read audio source: {e}"))?;
+    let (samples, sample_rate, duration) = decode_source_to_mono(std::io::BufReader::new(file))?;
     Ok(analyze_mono_samples(
         &samples,
         sample_rate,
@@ -408,4 +440,94 @@ pub fn analyze_audio_file(
 
 pub fn analyze_audio_source(req: AutomixAnalyzeSourceRequest) -> Result<TrackAnalysis, String> {
     analyze_audio_file(req.source, req.analyze_bpm.unwrap_or(true))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Minimal 16-bit PCM WAV with a 220 Hz sine, `frames` frames per channel.
+    fn wav_bytes(frames: usize, channels: u16, sample_rate: u32) -> Vec<u8> {
+        let data_len = frames * channels as usize * 2;
+        let mut out = Vec::with_capacity(44 + data_len);
+        out.extend_from_slice(b"RIFF");
+        out.extend_from_slice(&((36 + data_len) as u32).to_le_bytes());
+        out.extend_from_slice(b"WAVE");
+        out.extend_from_slice(b"fmt ");
+        out.extend_from_slice(&16u32.to_le_bytes());
+        out.extend_from_slice(&1u16.to_le_bytes());
+        out.extend_from_slice(&channels.to_le_bytes());
+        out.extend_from_slice(&sample_rate.to_le_bytes());
+        out.extend_from_slice(&(sample_rate * channels as u32 * 2).to_le_bytes());
+        out.extend_from_slice(&(channels * 2).to_le_bytes());
+        out.extend_from_slice(&16u16.to_le_bytes());
+        out.extend_from_slice(b"data");
+        out.extend_from_slice(&(data_len as u32).to_le_bytes());
+        for i in 0..frames {
+            let t = i as f32 / sample_rate as f32;
+            let v = ((std::f32::consts::TAU * 220.0 * t).sin() * 20_000.0) as i16;
+            for _ in 0..channels {
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn file_and_bytes_decode_paths_are_identical() {
+        let bytes = wav_bytes(44_100, 2, 44_100);
+
+        let (mono_bytes, rate_bytes, duration_bytes) =
+            decode_audio_to_mono(bytes.clone()).expect("bytes decode");
+
+        let mut tmp = tempfile::NamedTempFile::new().expect("temp file");
+        tmp.write_all(&bytes).expect("write wav");
+        tmp.flush().expect("flush wav");
+        let file = std::fs::File::open(tmp.path()).expect("open wav");
+        let (mono_file, rate_file, duration_file) =
+            decode_source_to_mono(std::io::BufReader::new(file)).expect("file decode");
+
+        assert_eq!(rate_bytes, rate_file);
+        assert_eq!(duration_bytes, duration_file);
+        assert_eq!(mono_bytes, mono_file);
+    }
+
+    #[test]
+    fn mono_buffer_is_preallocated_from_duration_hint() {
+        let frames = 2 * 44_100;
+        let (mono, rate, _) = decode_audio_to_mono(wav_bytes(frames, 2, 44_100)).expect("decode");
+
+        assert_eq!(rate, 44_100);
+        assert_eq!(mono.len(), frames);
+        assert!(mono.capacity() >= mono.len());
+        // With the hint-based preallocation, capacity must track the frame
+        // count closely; the old push-doubling growth would land on the next
+        // power of two (131072) and fail this bound.
+        assert!(
+            mono.capacity() <= mono.len() + mono.len() / 32 + 4096,
+            "capacity {} too far above len {}",
+            mono.capacity(),
+            mono.len()
+        );
+    }
+
+    #[test]
+    fn mono_capacity_hint_is_bounded_and_defensive() {
+        assert_eq!(mono_capacity_hint(None, 44_100), 0);
+        assert_eq!(mono_capacity_hint(Some(0.0), 44_100), 0);
+        assert_eq!(mono_capacity_hint(Some(f32::NAN), 44_100), 0);
+        assert_eq!(mono_capacity_hint(Some(-3.0), 44_100), 0);
+
+        let two_seconds = mono_capacity_hint(Some(2.0), 44_100);
+        assert!(two_seconds >= 2 * 44_100);
+        assert!(two_seconds <= 2 * 44_100 + (2 * 44_100) / 32 + 4096);
+
+        // A corrupt header claiming hours must not turn into a giant blind
+        // allocation.
+        assert_eq!(
+            mono_capacity_hint(Some(36_000.0), 192_000),
+            MONO_PREALLOC_MAX_SAMPLES
+        );
+    }
 }

--- a/src-tauri/crates/audio-backend/src/automix/mod.rs
+++ b/src-tauri/crates/audio-backend/src/automix/mod.rs
@@ -8,8 +8,9 @@
 /// returns full TrackAnalysis.
 use rodio::{Decoder, Source};
 use serde::{Deserialize, Serialize};
-use std::io::Cursor;
+use std::io::{Cursor, Read, Seek, SeekFrom};
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 // ─── Input ───────────────────────────────────────────────────────────
 
@@ -234,26 +235,95 @@ use vocal::analyze_vocal_activity;
 
 // ─── Main Analysis Entry Point ─────────────────────────────────────
 
-/// Cap for the duration-hint preallocation (in mono samples): 64M samples
-/// ≈ 256 MiB of f32, covering ~24 min @ 44.1 kHz or ~11 min @ 96 kHz. A
-/// corrupt container header claiming hours must not translate into a giant
-/// blind allocation — tracks longer than the cap simply fall back to doubling
-/// growth beyond it, which is never worse than the old un-hinted behavior.
+/// Cap for the duration-hint preallocation (in mono samples). On 64-bit
+/// targets: 64M samples ≈ 256 MiB of f32, covering ~24 min @ 44.1 kHz or
+/// ~11 min @ 96 kHz. On the 32-bit Android targets (armv7/i686) the cap is
+/// 16M samples ≈ 64 MiB so a corrupt header can never turn into a blind
+/// allocation that pressures a 32-bit address space. Tracks longer than the
+/// cap simply fall back to doubling growth beyond it, which is never worse
+/// than the old un-hinted behavior.
+#[cfg(target_pointer_width = "64")]
 const MONO_PREALLOC_MAX_SAMPLES: usize = 64 << 20;
+#[cfg(not(target_pointer_width = "64"))]
+const MONO_PREALLOC_MAX_SAMPLES: usize = 16 << 20;
 
 /// Mono-sample capacity estimate from the container duration hint, with a
 /// small headroom margin (~1.6% + 1024) so hints that undershoot slightly do
 /// not push the buffer into a full doubling reallocation for the excess.
+///
+/// The estimate is clamped in f64 space BEFORE any usize arithmetic: corrupt
+/// containers can report astronomical durations (symphonia maps the MP4 v0
+/// unknown-duration sentinel to u64::MAX seconds), and the saturating float
+/// cast plus margin addition must not overflow-panic on such hints.
 fn mono_capacity_hint(duration_hint: Option<f32>, sample_rate: u32) -> usize {
     let Some(duration) = duration_hint.filter(|d| d.is_finite() && *d > 0.0) else {
         return 0;
     };
-    let frames = (duration as f64 * sample_rate as f64).ceil() as usize;
-    (frames + frames / 64 + 1024).min(MONO_PREALLOC_MAX_SAMPLES)
+    let frames = (duration as f64 * sample_rate as f64).ceil();
+    if !frames.is_finite() || frames <= 0.0 {
+        return 0;
+    }
+    let frames = frames.min(MONO_PREALLOC_MAX_SAMPLES as f64) as usize;
+    frames
+        .saturating_add(frames / 64)
+        .saturating_add(1024)
+        .min(MONO_PREALLOC_MAX_SAMPLES)
 }
 
 fn decode_audio_to_mono(audio_data: Vec<u8>) -> Result<(Vec<f32>, u32, f32), String> {
     decode_source_to_mono(Cursor::new(audio_data))
+}
+
+/// Records the first genuine I/O error seen by the streamed decode source.
+///
+/// rodio/symphonia deliberately conflate mid-stream I/O errors with normal
+/// end-of-stream (symphonia signals EOF as `IoError(UnexpectedEof)`), so a
+/// dying disk or vanished network mount would otherwise silently truncate the
+/// decoded PCM and produce a "successful" analysis over partial audio. The
+/// old whole-file `fs::read` path surfaced every read error before decoding;
+/// latching restores exactly that property for the streamed path.
+/// `ErrorKind::Interrupted` is not latched to match `read_to_end`, which
+/// transparently retries it.
+struct IoErrorLatchReader<R> {
+    inner: R,
+    latch: Arc<Mutex<Option<String>>>,
+}
+
+impl<R> IoErrorLatchReader<R> {
+    fn record(&self, err: &std::io::Error) {
+        if err.kind() == std::io::ErrorKind::Interrupted {
+            return;
+        }
+        if let Ok(mut latch) = self.latch.lock() {
+            if latch.is_none() {
+                *latch = Some(err.to_string());
+            }
+        }
+    }
+}
+
+impl<R: Read> Read for IoErrorLatchReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self.inner.read(buf) {
+            Ok(n) => Ok(n),
+            Err(err) => {
+                self.record(&err);
+                Err(err)
+            }
+        }
+    }
+}
+
+impl<R: Seek> Seek for IoErrorLatchReader<R> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        match self.inner.seek(pos) {
+            Ok(offset) => Ok(offset),
+            Err(err) => {
+                self.record(&err);
+                Err(err)
+            }
+        }
+    }
 }
 
 fn decode_source_to_mono<R>(input: R) -> Result<(Vec<f32>, u32, f32), String>
@@ -429,7 +499,18 @@ pub fn analyze_audio_file(
     // Cursor) for the entire full-track decode, adding the whole file size on
     // top of the PCM buffer at the peak.
     let file = std::fs::File::open(path.as_ref()).map_err(|e| format!("read audio source: {e}"))?;
-    let (samples, sample_rate, duration) = decode_source_to_mono(std::io::BufReader::new(file))?;
+    let io_error = Arc::new(Mutex::new(None));
+    let reader = IoErrorLatchReader {
+        inner: std::io::BufReader::new(file),
+        latch: Arc::clone(&io_error),
+    };
+    let decoded = decode_source_to_mono(reader);
+    // Surface underlying disk errors exactly like the old whole-file read did,
+    // whether or not the decoder managed to limp past them with partial PCM.
+    if let Some(err) = io_error.lock().ok().and_then(|mut latch| latch.take()) {
+        return Err(format!("read audio source: {err}"));
+    }
+    let (samples, sample_rate, duration) = decoded?;
     Ok(analyze_mono_samples(
         &samples,
         sample_rate,
@@ -528,6 +609,81 @@ mod tests {
         assert_eq!(
             mono_capacity_hint(Some(36_000.0), 192_000),
             MONO_PREALLOC_MAX_SAMPLES
+        );
+
+        // Astronomical hints (symphonia maps the MP4 v0 unknown-duration
+        // sentinel to u64::MAX seconds) must clamp without overflow-panicking
+        // in dev/test builds, on 32-bit and 64-bit targets alike.
+        assert_eq!(
+            mono_capacity_hint(Some(f32::MAX), u32::MAX),
+            MONO_PREALLOC_MAX_SAMPLES
+        );
+        assert_eq!(
+            mono_capacity_hint(Some(u64::MAX as f32), 44_100),
+            MONO_PREALLOC_MAX_SAMPLES
+        );
+    }
+
+    /// Read+Seek source that fails with a genuine I/O error after a byte budget,
+    /// simulating a dying disk / vanished network mount mid-decode.
+    struct FailAfter {
+        inner: Cursor<Vec<u8>>,
+        remaining: usize,
+    }
+
+    impl Read for FailAfter {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if self.remaining == 0 {
+                return Err(std::io::Error::other("injected io failure"));
+            }
+            let limit = buf.len().min(self.remaining);
+            let read = self.inner.read(&mut buf[..limit])?;
+            self.remaining -= read;
+            Ok(read)
+        }
+    }
+
+    impl Seek for FailAfter {
+        fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+            self.inner.seek(pos)
+        }
+    }
+
+    #[test]
+    fn mid_stream_io_errors_are_latched() {
+        let bytes = wav_bytes(44_100, 2, 44_100);
+        let budget = bytes.len() / 2;
+        let latch = Arc::new(Mutex::new(None));
+        let reader = IoErrorLatchReader {
+            inner: FailAfter {
+                inner: Cursor::new(bytes),
+                remaining: budget,
+            },
+            latch: Arc::clone(&latch),
+        };
+
+        // rodio/symphonia conflate the mid-stream failure with end-of-stream,
+        // so the decode itself may "succeed" with truncated PCM — the latch is
+        // what lets analyze_audio_file surface it as a read error.
+        let _ = decode_source_to_mono(reader);
+        let recorded = latch
+            .lock()
+            .unwrap()
+            .take()
+            .expect("io error must be latched");
+        assert!(
+            recorded.contains("injected io failure"),
+            "unexpected latched error: {recorded}"
+        );
+    }
+
+    #[test]
+    fn analyze_audio_file_surfaces_unreadable_source_as_read_error() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let err = analyze_audio_file(dir.path(), false).expect_err("directory must not analyze");
+        assert!(
+            err.starts_with("read audio source:"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/src-tauri/crates/audio-backend/src/decoder/mod.rs
+++ b/src-tauri/crates/audio-backend/src/decoder/mod.rs
@@ -1080,6 +1080,19 @@ fn read_input_frame(
     buf: &mut [f32],
 ) -> bool {
     debug_assert_eq!(buf.len(), channels);
+
+    // Fast path: the whole frame sits inside the current decoded buffer, so
+    // copy it as one slice — the resample/mix hot loop calls this per output
+    // frame and the per-sample `next()` chain costs a branch per sample.
+    let samples = source.buffer.samples();
+    let offset = source.buffer_offset;
+    if offset + channels <= samples.len() {
+        buf[..channels].copy_from_slice(&samples[offset..offset + channels]);
+        source.buffer_offset = offset + channels;
+        return true;
+    }
+
+    // Slow path: the frame straddles a refill boundary (or the source ends).
     for slot in &mut buf[..channels] {
         match source.next() {
             Some(sample) => *slot = sample,

--- a/src-tauri/crates/audio-backend/src/player/mixer.rs
+++ b/src-tauri/crates/audio-backend/src/player/mixer.rs
@@ -558,14 +558,14 @@ impl DeckRuntime {
             let avail = self.current_block.len() - self.current_index;
             let run = (samples - written).min(avail);
             let src = &self.current_block[self.current_index..self.current_index + run];
+            // `extend` over a slice iterator is TrustedLen-specialized: one
+            // reserve, then straight writes with no per-element capacity check,
+            // which keeps this run vectorizable (a push loop re-checks capacity
+            // every sample).
             if gain == 1.0 {
-                for &s in src {
-                    dst.push(s.clamp(-1.0, 1.0));
-                }
+                dst.extend(src.iter().map(|&s| s.clamp(-1.0, 1.0)));
             } else {
-                for &s in src {
-                    dst.push((s * gain).clamp(-1.0, 1.0));
-                }
+                dst.extend(src.iter().map(|&s| (s * gain).clamp(-1.0, 1.0)));
             }
             self.current_index += run;
             written += run;

--- a/src/utils/AudioContext/AutoMix/TrackAnalyzer.ts
+++ b/src/utils/AudioContext/AutoMix/TrackAnalyzer.ts
@@ -195,6 +195,25 @@ async function decodeBlob(blobUrl: string, ctx: AudioContext): Promise<AudioBuff
 }
 
 /**
+ * Decode and immediately mix down to mono inside a narrow scope, so the
+ * multi-channel AudioBuffer (~2× the mono PCM for stereo, ~85MB for a 4-min
+ * 44.1kHz track) becomes collectable as soon as this helper returns, instead
+ * of staying pinned by the caller's async frame for the entire Worker
+ * analysis (up to 30s).
+ */
+async function decodeToMonoPcm(
+  sourceUrl: string,
+  ctx: AudioContext,
+): Promise<{ monoData: Float32Array; sampleRate: number; duration: number }> {
+  const buffer = await decodeBlob(sourceUrl, ctx);
+  return {
+    monoData: mixToMono(buffer),
+    sampleRate: buffer.sampleRate,
+    duration: buffer.duration,
+  };
+}
+
+/**
  * Mix AudioBuffer to mono Float32Array.
  */
 function mixToMono(buffer: AudioBuffer): Float32Array {
@@ -461,13 +480,11 @@ export async function analyzeTrack(
     return workerClient.analyzeBytesViaWorker(fetchResult.bytes, extension, analyzeBPM);
   }
 
-  // Step 1: decode on main thread using global AudioContext when available.
-  const buffer = await decodeBlob(sourceUrl, ctx);
-
-  // Step 2: mix to mono
-  const monoData = mixToMono(buffer);
-  const sampleRate = buffer.sampleRate;
-  const duration = buffer.duration;
+  // Steps 1-2: decode on main thread using the global AudioContext and mix
+  // to mono. Done inside a helper so the decoded AudioBuffer is released for
+  // GC before the analysis phase below runs (identical samples — only the
+  // buffer's lifetime changes).
+  const { monoData, sampleRate, duration } = await decodeToMonoPcm(sourceUrl, ctx);
 
   // Step 3: dispatch to Worker or fall back
   if (workerClient?.hasAnalysisWorker()) {

--- a/src/utils/tauri/NativeRustSound.ts
+++ b/src/utils/tauri/NativeRustSound.ts
@@ -115,6 +115,10 @@ export class NativeRustSound implements ISound {
    */
   private _seenEventSeq: Set<number> = new Set();
   private _seenEventSeqOrder: number[] = [];
+  /** Index of the oldest live entry in `_seenEventSeqOrder` — eviction moves
+   * this head forward instead of `Array#shift`, which is O(window) per event
+   * once the window is full (i.e. for every event after the first ~512). */
+  private _seenEventSeqHead = 0;
 
   /** Track metadata from SyncStatus / LoadAudio. */
   private _musicInfo: DisplayAudioInfo | null = null;
@@ -728,9 +732,16 @@ export class NativeRustSound implements ISound {
 
     this._seenEventSeq.add(seq);
     this._seenEventSeqOrder.push(seq);
-    while (this._seenEventSeqOrder.length > SEEN_EVENT_SEQ_LIMIT) {
-      const oldSeq = this._seenEventSeqOrder.shift();
+    while (this._seenEventSeqOrder.length - this._seenEventSeqHead > SEEN_EVENT_SEQ_LIMIT) {
+      const oldSeq = this._seenEventSeqOrder[this._seenEventSeqHead];
+      this._seenEventSeqHead++;
       if (oldSeq !== undefined) this._seenEventSeq.delete(oldSeq);
+    }
+    // Drop the consumed prefix once it dominates the array so the backing
+    // storage stays bounded at ~2× the dedup window.
+    if (this._seenEventSeqHead >= SEEN_EVENT_SEQ_LIMIT) {
+      this._seenEventSeqOrder = this._seenEventSeqOrder.slice(this._seenEventSeqHead);
+      this._seenEventSeqHead = 0;
     }
     return false;
   }
@@ -1219,6 +1230,7 @@ export class NativeRustSound implements ISound {
     this._onceEvents = {};
     this._seenEventSeq.clear();
     this._seenEventSeqOrder.length = 0;
+    this._seenEventSeqHead = 0;
     this._state.playlist = [];
     this._musicInfo = null;
     this._quality = null;


### PR DESCRIPTION
…aths

Behavior-preserving performance cleanups across the native audio pipeline
and the audio IPC event path:

- audio-analysis: split the shared FFT frame pipeline out of read_spectrum
  and add AudioProcessor::process_frame_raw / FftProcessor::read_spectrum_raw
  for the native IPC path. The native analysis thread only consumes
  raw_spectrum() and the lowFreq value, so it no longer pays the WASM-only
  0-255 normalization/EMA pass (~2048 sqrt + peak scan + smoothing writes)
  plus a discarded 2048-float spectrum copy on every 16 ms tick. The WASM
  paths keep using process_frame unchanged, and a new equivalence test
  asserts raw_spectrum/get_raw_bins/lowFreq stay bit-identical between the
  two pipelines.

- analysis loop: drop the 2048-float scratch buffer that only existed to
  receive the discarded normalized spectrum.

- mixer: fill_scaled now bulk-copies via TrustedLen extend instead of a
  per-sample Vec::push loop, removing the per-element capacity check from
  the single-deck steady-state fill (identical values, clamp and order;
  covered by existing fill_scaled tests).

- decoder: read_input_frame gets a frame-sized copy_from_slice fast path
  when the whole frame is inside the current decoded buffer, cutting the
  per-sample Option/branch chain in the resample/channel-mix path; the
  per-sample fallback still handles refill boundaries and EOF exactly as
  before.

- NativeRustSound: the event seq dedup window evicts via a moving head
  index instead of Array#shift, which was O(window) for every incoming
  event once the 512-entry window filled (~8 s into playback). Set
  membership and eviction order are unchanged.

Validation: cargo test -p audio-analysis -p gmplayer-audio-backend (56
passed), cargo check for wasm32-unknown-unknown on both crates, rustfmt
--check on touched files, oxlint + oxfmt --check on the touched TS file,
and pnpm build.