### PR TITLE
perf(Tauri): 收敛 WebView2 运行时内存占用

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,11 @@ Frontend seek/autoresume must preserve the optimistic position anchor. After a s
 
 Lyrics support LRC, YRC, and TTML. Fetching and normalization live under `src/utils/LyricsProcessor/`, while AMLL rendering powers rich lyric views.
 
-Tauri windows are created through Rust-side presets in `src-tauri/src/desktop/window/config.rs` and `manager.rs`. On Windows, WebView2 windows that share a profile must use consistent additional browser args.
+Tauri windows are created through Rust-side presets in `src-tauri/src/desktop/window/config.rs` and `manager.rs`. On Windows, WebView2 windows that share a profile must use consistent additional browser args, so `DEFAULT_ADDITIONAL_WINDOW_ARGS` is the only definition and every window (including the taskbar lyric plugin's) gets it verbatim. That string replaces wry's defaults rather than extending them — keep `msWebOOUI,msPdfOOUI,msSmartScreenProtection` in the merged `--disable-features` list, and keep hardware acceleration on: the player animates continuously, so `--disable-gpu` is not an acceptable memory trade here.
+
+Hidden windows keep a full WebView2 renderer, and hiding a Tauri window only hides the host HWND. `src-tauri/src/desktop/window/webview_memory.rs` drives the engine-side policy from the show/hide paths: every managed window drops to `MemoryUsageTargetLevel::Low` while hidden and returns to `Normal` before it is shown again, the windows in `IDLE_WHEN_HIDDEN` additionally get `IsVisible = false`, and the ones in `SUSPEND_WHEN_HIDDEN` (a subset — `TrySuspend` fails unless the controller is already invisible) are frozen outright. The main window must stay out of both lists — it is the playback master and keeps driving the AutoMix monitor and slave broadcasts from rAF and timers while the app sits in the tray. Always call `webview_memory::on_shown` *before* `show()` so the wake request precedes the show on the shared event loop queue. Pre-created hidden windows are put to sleep from `on_page_load`, never at build time: navigation auto-resumes a suspended webview, so suspending mid-load would both fail and leave a half-rendered page for the first open.
+
+Do not add a periodic reload to "refresh" a long-running window. `main` owns playback, the native audio bridge and the AutoMix state machine, and every other window is already destroyed on close; the only permanently resident page is the tray popup, which is suspended instead.
 
 ## AutoMix & Crossfade Rules
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2023,6 +2023,7 @@ dependencies = [
  "tauri-plugin-taskbar-lyric",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "webview2-com",
  "windows 0.61.3",
  "windows-sys 0.59.0",
  "windows-version",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,6 +64,10 @@ gmplayer-now-playing-controls = { package = "tauri-plugin-now-playing-controls",
 [target.'cfg(windows)'.dependencies]
 gmplayer-taskbar-lyric = { package = "tauri-plugin-taskbar-lyric", path = "crates/taskbar-lyric" }
 windows-version = "0.1.7"
+# WebView2 COM interfaces for the idle-memory policy (MemoryUsageTargetLevel /
+# controller visibility). Must stay on the version wry resolves, or the
+# controller handed out by `PlatformWebview` is a different type.
+webview2-com = "0.38"
 windows = { version = "0.61.3", features = [
   "Win32_Foundation",
   "Win32_Graphics_Direct2D",

--- a/src-tauri/src/desktop/mod.rs
+++ b/src-tauri/src/desktop/mod.rs
@@ -200,12 +200,15 @@ pub fn run() {
                     let _ = app_handle.save_window_state(WINDOW_STATE_FLAGS);
                     let _ = app_handle.emit("main-close-requested", ());
                 }
-                // Tray popup loses focus → hide it
+                // Tray popup loses focus → hide it. Routed through the window
+                // manager so the dismissed popup also drops to the low WebView2
+                // memory target instead of idling at full footprint.
                 ("tray-popup", WindowEvent::Focused(false)) => {
-                    if let Some(popup) = app_handle.get_webview_window("tray-popup") {
-                        let _ = popup.hide();
+                    if let Err(e) = wm::hide_window(app_handle, "tray-popup") {
+                        warn!("Failed to hide tray popup on focus loss: {}", e);
                     }
                 }
+                (_, WindowEvent::Destroyed) => wm::on_window_destroyed(app_handle, label),
                 _ => {}
             }
         }

--- a/src-tauri/src/desktop/window/config.rs
+++ b/src-tauri/src/desktop/window/config.rs
@@ -1,10 +1,62 @@
 use serde::{Deserialize, Serialize};
 
-#[cfg(all(target_os = "windows", debug_assertions))]
-pub const DEFAULT_ADDITIONAL_WINDOW_ARGS: &str = "--enable-gpu-rasterization --enable-zero-copy --ignore-gpu-blocklist --use-gl=angle --disable-features=VaapiVideoDecoder,UseChromeOSDirectVideoDecoder,msWebOOUI,msPdfOOUI --enable-threaded-compositing --num-raster-threads=4 --remote-debugging-port=9222";
+/// The parts of the WebView2 command line that are identical in every build.
+///
+/// Kept as a macro so the debug-only remote debugging port can be appended at
+/// compile time without duplicating the list.
+#[cfg(target_os = "windows")]
+macro_rules! window_args {
+    () => {
+        concat!(
+            // Rendering. The player animates continuously (lyrics, spectrum,
+            // cover blur), so hardware acceleration stays on: `--disable-gpu`
+            // is only a sensible memory trade for static UI.
+            "--enable-gpu-rasterization --enable-zero-copy --ignore-gpu-blocklist --use-gl=angle ",
+            "--enable-threaded-compositing --num-raster-threads=4 ",
+            // One merged `--disable-features` list; a second occurrence would
+            // replace this one instead of extending it.
+            "--disable-features=",
+            "VaapiVideoDecoder,UseChromeOSDirectVideoDecoder,",
+            // wry's defaults. Passing `additional_browser_args` replaces them
+            // wholesale, so they have to be repeated or they come back on.
+            "msWebOOUI,msPdfOOUI,msSmartScreenProtection,",
+            // Edge consumer services the player never uses. Each one is a
+            // resident chunk of the browser process.
+            "msEdgeAutofill,msEdgeShopping,msEdgeWallet,",
+            // Browser retention experiment; Microsoft documents it as
+            // unsupported in WebView2.
+            "msFloatyMode,",
+            // A warm spare renderer process kept alive at all times to make the
+            // *next* window open faster. This app opens windows rarely, so the
+            // spare is a whole process of resident memory for a win we never
+            // collect.
+            "SpareRendererForSitePerProcess ",
+            // Cap V8's young generation per renderer: smaller heaps, more
+            // frequent but individually cheaper minor GCs. 8 MB is Microsoft's
+            // documented example value.
+            "--js-flags=--scavenger_max_new_space_capacity_mb=8 ",
+            // Bound the HTTP cache (covers, API responses); the default
+            // heuristic sizes it from free disk space and grows well past this.
+            "--disk-cache-size=67108864",
+        )
+    };
+}
 
+/// Browser command line shared by every WebView2 window in the app.
+///
+/// One user data folder means one WebView2 environment, and WebView2 requires
+/// consistent arguments across it (see [`WindowConfig::effective_additional_args`]),
+/// so this is the single definition — the taskbar lyric plugin is handed the
+/// same string.
+#[cfg(all(target_os = "windows", debug_assertions))]
+pub const DEFAULT_ADDITIONAL_WINDOW_ARGS: &str =
+    concat!(window_args!(), " --remote-debugging-port=9222");
+
+/// Browser command line shared by every WebView2 window in the app.
+///
+/// See the debug variant above for the rationale behind each group of flags.
 #[cfg(all(target_os = "windows", not(debug_assertions)))]
-pub const DEFAULT_ADDITIONAL_WINDOW_ARGS: &str = "--enable-gpu-rasterization --enable-zero-copy --ignore-gpu-blocklist --use-gl=angle --disable-features=VaapiVideoDecoder,UseChromeOSDirectVideoDecoder,msWebOOUI,msPdfOOUI --enable-threaded-compositing --num-raster-threads=4";
+pub const DEFAULT_ADDITIONAL_WINDOW_ARGS: &str = window_args!();
 
 pub const TRAY_POPUP_WIDTH: f64 = 260.0;
 pub const TRAY_POPUP_BASE_HEIGHT: f64 = 334.0;
@@ -405,5 +457,43 @@ impl WindowConfig {
     #[cfg(not(target_os = "windows"))]
     pub fn effective_additional_args(&self) -> Option<&str> {
         self.additional_args.as_deref()
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::DEFAULT_ADDITIONAL_WINDOW_ARGS as ARGS;
+
+    /// The command line is assembled from string fragments, so a dropped
+    /// trailing space silently glues two switches into one unknown switch.
+    #[test]
+    fn browser_args_are_well_formed() {
+        assert!(!ARGS.contains("  "), "double space in {ARGS}");
+        assert!(!ARGS.starts_with(' ') && !ARGS.ends_with(' '));
+        for arg in ARGS.split(' ') {
+            assert!(
+                arg.starts_with("--"),
+                "malformed argument '{arg}' in {ARGS}"
+            );
+        }
+    }
+
+    /// Chromium keeps only the last occurrence of a switch, so every feature to
+    /// disable has to live in one list.
+    #[test]
+    fn disabled_features_are_a_single_list() {
+        let lists: Vec<&str> = ARGS
+            .split(' ')
+            .filter_map(|arg| arg.strip_prefix("--disable-features="))
+            .collect();
+        assert_eq!(lists.len(), 1, "expected exactly one --disable-features");
+        // wry passes these by default and `additional_browser_args` replaces
+        // its defaults rather than extending them.
+        for wry_default in ["msWebOOUI", "msPdfOOUI", "msSmartScreenProtection"] {
+            assert!(
+                lists[0].split(',').any(|feature| feature == wry_default),
+                "wry default '{wry_default}' was dropped"
+            );
+        }
     }
 }

--- a/src-tauri/src/desktop/window/manager.rs
+++ b/src-tauri/src/desktop/window/manager.rs
@@ -1,11 +1,11 @@
-use crate::desktop::window::{config::WindowConfig, effects};
+use crate::desktop::window::{config::WindowConfig, effects, webview_memory};
 use log::info;
 use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(not(target_os = "windows"))]
 use tauri::Theme;
 use tauri::{
-    AppHandle, Emitter, LogicalSize, Manager, PhysicalPosition, WebviewUrl, WebviewWindow,
-    WebviewWindowBuilder,
+    webview::PageLoadEvent, AppHandle, Emitter, LogicalSize, Manager, PhysicalPosition, WebviewUrl,
+    WebviewWindow, WebviewWindowBuilder,
 };
 #[cfg(target_os = "macos")]
 use tauri_plugin_decorum::WebviewWindowExt;
@@ -36,6 +36,7 @@ pub fn create_window(app: &AppHandle, config: &WindowConfig) -> Result<(), Strin
         if let Some(existing) = app.get_webview_window(label) {
             info!("Window '{}' already exists, focusing", label);
             apply_runtime_size_constraints(&existing, config)?;
+            webview_memory::on_shown(&existing);
             existing.show().map_err(|e| e.to_string())?;
             if existing.is_minimized().unwrap_or(false) {
                 existing.unminimize().map_err(|e| e.to_string())?;
@@ -111,6 +112,19 @@ pub fn create_window(app: &AppHandle, config: &WindowConfig) -> Result<(), Strin
         if !args.is_empty() {
             builder = builder.additional_browser_args(args);
         }
+    }
+
+    // Windows that are pre-created hidden (tray popup, lyric controls) sit
+    // there for the whole session, so put them to sleep as soon as their page
+    // is loaded. `main` is excluded: it is only hidden for the moment it takes
+    // the frontend to pick a theme and reveal it, and nothing on that path
+    // would wake it back up.
+    if !config.visible && label != "main" {
+        builder = builder.on_page_load(|window, payload| {
+            if matches!(payload.event(), PageLoadEvent::Finished) {
+                webview_memory::on_loaded_while_hidden(&window);
+            }
+        });
     }
 
     // Apply min/max size constraints. Each dimension defaults to 0.0 if unset,
@@ -328,6 +342,7 @@ pub fn show_window(app: &AppHandle, label: &str) -> Result<(), String> {
     let window = app
         .get_webview_window(label)
         .ok_or_else(|| format!("Window '{}' not found", label))?;
+    webview_memory::on_shown(&window);
     window.show().map_err(|e| e.to_string())?;
     window.set_focus().map_err(|e| e.to_string())?;
     if label == "main" {
@@ -343,6 +358,7 @@ pub fn hide_window(app: &AppHandle, label: &str) -> Result<(), String> {
         .get_webview_window(label)
         .ok_or_else(|| format!("Window '{}' not found", label))?;
     window.hide().map_err(|e| e.to_string())?;
+    webview_memory::on_hidden(&window);
     if label == "main" {
         let _ = app.emit("main-window-visibility", false);
     }
@@ -367,6 +383,16 @@ pub fn close_window(app: &AppHandle, label: &str) -> Result<(), String> {
     window.destroy().map_err(|e| e.to_string())
 }
 
+/// A managed window was destroyed.
+///
+/// Announcing the close as a visibility change lets the master drop the window
+/// from its broadcast set immediately, instead of waiting for the reconcile
+/// poll to notice it is gone.
+pub fn on_window_destroyed(app: &AppHandle, label: &str) {
+    webview_memory::forget(label);
+    emit_window_visibility(app, label, false);
+}
+
 /// Toggle visibility of a window by label.
 pub fn toggle_window(app: &AppHandle, label: &str) -> Result<(), String> {
     let window = app
@@ -376,12 +402,14 @@ pub fn toggle_window(app: &AppHandle, label: &str) -> Result<(), String> {
     let is_visible = window.is_visible().map_err(|e| e.to_string())?;
     if is_visible {
         window.hide().map_err(|e| e.to_string())?;
+        webview_memory::on_hidden(&window);
         if label == "main" {
             let _ = app.emit("main-window-visibility", false);
         }
         emit_window_visibility(app, label, false);
         Ok(())
     } else {
+        webview_memory::on_shown(&window);
         window.show().map_err(|e| e.to_string())?;
         // Only unminimize if actually minimized — calling unminimize on a
         // hidden-but-not-minimized window can reset its size on Windows.
@@ -402,6 +430,7 @@ pub fn focus_window(app: &AppHandle, label: &str) -> Result<(), String> {
     let window = app
         .get_webview_window(label)
         .ok_or_else(|| format!("Window '{}' not found", label))?;
+    webview_memory::on_shown(&window);
     window.show().map_err(|e| e.to_string())?;
     if window.is_minimized().unwrap_or(false) {
         window.unminimize().map_err(|e| e.to_string())?;
@@ -459,6 +488,7 @@ pub fn show_window_at_position(app: &AppHandle, label: &str, x: f64, y: f64) -> 
     window
         .set_position(PhysicalPosition::new(x as i32, y as i32))
         .map_err(|e| e.to_string())?;
+    webview_memory::on_shown(&window);
     window.show().map_err(|e| e.to_string())?;
     window.set_focus().map_err(|e| e.to_string())?;
     emit_window_visibility(app, label, true);

--- a/src-tauri/src/desktop/window/mod.rs
+++ b/src-tauri/src/desktop/window/mod.rs
@@ -9,3 +9,4 @@ pub mod manager;
 mod minimize_guard;
 pub mod payload;
 pub mod tray;
+pub mod webview_memory;

--- a/src-tauri/src/desktop/window/webview_memory.rs
+++ b/src-tauri/src/desktop/window/webview_memory.rs
@@ -1,0 +1,252 @@
+//! Idle-memory policy for managed WebView2 windows.
+//!
+//! Every window in the app shares one WebView2 environment, so a window that is
+//! merely hidden still owns a live renderer process. Hiding a Tauri window only
+//! hides the host HWND — the WebView2 controller keeps reporting itself as
+//! visible, so the engine keeps compositing and the page keeps its `visible`
+//! visibility state. Three engine-side knobs fix that, all driven from the
+//! window show/hide paths in [`super::manager`]:
+//!
+//! * `MemoryUsageTargetLevel` — `Low` asks the engine to drop cached data and
+//!   trim its working set, restored to `Normal` before the window returns.
+//!   Applied to every managed window; it changes no scheduling, only footprint.
+//! * `IsVisible` — tells the engine the control is off screen, which stops its
+//!   compositor and moves the page to the throttled `hidden` state. Applied
+//!   only to [`IDLE_WHEN_HIDDEN`], because that throttling stops rAF and timers.
+//! * `TrySuspend` — freezes the renderer process outright so the OS can reclaim
+//!   its memory. Applied only to [`SUSPEND_WHEN_HIDDEN`], and only after
+//!   `IsVisible` is false, which WebView2 requires (`ERROR_INVALID_STATE`
+//!   otherwise).
+//!
+//! Everything here is best effort: an older Evergreen runtime does not expose
+//! `ICoreWebView2_19`, `TrySuspend` itself is documented as best effort, and a
+//! failed COM call must never take a window show/hide down with it.
+
+use tauri::WebviewWindow;
+
+/// Managed windows whose page has nothing to do while hidden, so the engine may
+/// be told they are off screen.
+///
+/// `main` is deliberately absent. It is the playback master: while the app sits
+/// in the tray it still drives the AutoMix monitor and broadcasts time anchors
+/// and lyric payloads to the lyric windows, and all of that hangs off rAF and
+/// timers that the hidden visibility state would throttle. The mini player and
+/// lyric windows never reach the hidden path — they are destroyed when closed.
+#[cfg(target_os = "windows")]
+const IDLE_WHEN_HIDDEN: &[&str] = &["tray-popup", "desktop-lyrics-controls"];
+
+/// Windows that are additionally suspended while hidden. Always a subset of
+/// [`IDLE_WHEN_HIDDEN`], since `TrySuspend` requires an invisible controller.
+///
+/// Only the tray popup qualifies: it is pre-created, spends nearly the whole
+/// session hidden, is dismissed on focus loss, and re-syncs from the
+/// `tray-popup-opened` event every time it opens. `desktop-lyrics-controls` is
+/// excluded on purpose — it toggles with pointer hover, where a resume on every
+/// show would be felt.
+#[cfg(target_os = "windows")]
+const SUSPEND_WHEN_HIDDEN: &[&str] = &["tray-popup"];
+
+/// A window became visible: undo whatever [`on_hidden`] applied.
+///
+/// Call this *before* showing the window. `with_webview` and the show request
+/// travel the same event loop queue, so ordering the calls this way guarantees
+/// the engine is awake by the time the window is on screen.
+pub fn on_shown(window: &WebviewWindow) {
+    #[cfg(target_os = "windows")]
+    imp::wake(window);
+    #[cfg(not(target_os = "windows"))]
+    let _ = window;
+}
+
+/// A window was hidden but kept alive (close-to-tray, tray popup dismissal).
+pub fn on_hidden(window: &WebviewWindow) {
+    #[cfg(target_os = "windows")]
+    imp::sleep(window);
+    #[cfg(not(target_os = "windows"))]
+    let _ = window;
+}
+
+/// A window that was created hidden finished loading its page.
+///
+/// This is where pre-created windows go to sleep. Suspending earlier would
+/// fight the initial navigation — WebView2 auto-resumes on navigate — and would
+/// leave a half-loaded page to finish rendering on first open. A window that
+/// was already shown in the meantime is left alone.
+pub fn on_loaded_while_hidden(window: &WebviewWindow) {
+    #[cfg(target_os = "windows")]
+    imp::sleep_if_untouched(window);
+    #[cfg(not(target_os = "windows"))]
+    let _ = window;
+}
+
+/// Drop a destroyed window from the tracked state.
+pub fn forget(label: &str) {
+    #[cfg(target_os = "windows")]
+    imp::forget(label);
+    #[cfg(not(target_os = "windows"))]
+    let _ = label;
+}
+
+#[cfg(target_os = "windows")]
+mod imp {
+    use super::{WebviewWindow, IDLE_WHEN_HIDDEN, SUSPEND_WHEN_HIDDEN};
+    use std::sync::Mutex;
+    use webview2_com::Microsoft::Web::WebView2::Win32::{
+        ICoreWebView2, ICoreWebView2Controller, ICoreWebView2_19, ICoreWebView2_3,
+        COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL, COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL_LOW,
+        COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL_NORMAL,
+    };
+    use webview2_com::TrySuspendCompletedHandler;
+    use windows::core::{Interface, BOOL};
+
+    /// Labels believed to be on screen.
+    ///
+    /// Only [`sleep_if_untouched`] reads it, to resolve the one race that
+    /// matters: a tray click that lands while the pre-created popup is still
+    /// loading would otherwise be followed by a page-load callback that puts a
+    /// visible window to sleep. Bounded by the app's window labels, and
+    /// destroyed windows are dropped through [`forget`].
+    static AWAKE: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+    fn mark_awake(label: &str) {
+        let Ok(mut awake) = AWAKE.lock() else { return };
+        if !awake.iter().any(|known| known == label) {
+            awake.push(label.to_owned());
+        }
+    }
+
+    fn mark_asleep(label: &str) {
+        let Ok(mut awake) = AWAKE.lock() else { return };
+        awake.retain(|known| known != label);
+    }
+
+    fn is_awake(label: &str) -> bool {
+        AWAKE
+            .lock()
+            .map(|awake| awake.iter().any(|known| known == label))
+            .unwrap_or(false)
+    }
+
+    pub fn forget(label: &str) {
+        mark_asleep(label);
+    }
+
+    /// Run `f` against the window's WebView2 on the UI thread.
+    fn dispatch<F>(window: &WebviewWindow, f: F)
+    where
+        F: FnOnce(&ICoreWebView2Controller, &ICoreWebView2, &str) + Send + 'static,
+    {
+        let label = window.label().to_owned();
+        let result = window.with_webview(move |webview| {
+            let controller = webview.controller();
+            let core = match unsafe { controller.CoreWebView2() } {
+                Ok(core) => core,
+                Err(error) => {
+                    log::warn!("Failed to reach '{label}' CoreWebView2: {error}");
+                    return;
+                }
+            };
+            f(&controller, &core, &label);
+        });
+        if let Err(error) = result {
+            log::warn!(
+                "Failed to dispatch webview memory policy for '{}': {}",
+                window.label(),
+                error
+            );
+        }
+    }
+
+    pub fn wake(window: &WebviewWindow) {
+        mark_awake(window.label());
+        let restore_visible = IDLE_WHEN_HIDDEN.contains(&window.label());
+        dispatch(window, move |controller, core, label| unsafe {
+            // Resume before the control goes back on screen. WebView2 also
+            // auto-resumes on visible, but doing it first keeps the order
+            // deterministic and matches Microsoft's own sample.
+            resume(core, label);
+            if restore_visible {
+                if let Err(error) = controller.SetIsVisible(true) {
+                    log::warn!("Failed to show '{label}' webview control: {error}");
+                }
+            }
+            set_memory_level(core, COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL_NORMAL, label);
+        });
+    }
+
+    pub fn sleep(window: &WebviewWindow) {
+        mark_asleep(window.label());
+        let hide_control = IDLE_WHEN_HIDDEN.contains(&window.label());
+        let suspend = SUSPEND_WHEN_HIDDEN.contains(&window.label());
+        dispatch(window, move |controller, core, label| unsafe {
+            // Order is load-bearing: `TrySuspend` fails unless the controller is
+            // already invisible, and it freezes script, so the memory target has
+            // to be written before it.
+            if hide_control {
+                if let Err(error) = controller.SetIsVisible(false) {
+                    log::warn!("Failed to hide '{label}' webview control: {error}");
+                }
+            }
+            set_memory_level(core, COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL_LOW, label);
+            if suspend {
+                try_suspend(core, label);
+            }
+        });
+    }
+
+    pub fn sleep_if_untouched(window: &WebviewWindow) {
+        if is_awake(window.label()) {
+            return;
+        }
+        sleep(window);
+    }
+
+    /// `ICoreWebView2_19`, runtime 114+. Older Evergreen runtimes simply do not
+    /// get this optimization.
+    unsafe fn set_memory_level(
+        core: &ICoreWebView2,
+        level: COREWEBVIEW2_MEMORY_USAGE_TARGET_LEVEL,
+        label: &str,
+    ) {
+        let Ok(memory) = core.cast::<ICoreWebView2_19>() else {
+            return;
+        };
+        if let Err(error) = unsafe { memory.SetMemoryUsageTargetLevel(level) } {
+            log::warn!("Failed to set '{label}' memory usage target: {error}");
+        }
+    }
+
+    unsafe fn resume(core: &ICoreWebView2, label: &str) {
+        let Ok(lifecycle) = core.cast::<ICoreWebView2_3>() else {
+            return;
+        };
+        let mut suspended = BOOL::default();
+        if unsafe { lifecycle.IsSuspended(&mut suspended) }.is_err() || !suspended.as_bool() {
+            return;
+        }
+        if let Err(error) = unsafe { lifecycle.Resume() } {
+            log::warn!("Failed to resume '{label}' webview: {error}");
+        }
+    }
+
+    unsafe fn try_suspend(core: &ICoreWebView2, label: &str) {
+        let Ok(lifecycle) = core.cast::<ICoreWebView2_3>() else {
+            return;
+        };
+        // Best effort by contract: a page holding a lock, a running script or an
+        // active media/download keeps the renderer alive and reports
+        // `is_successful = false` with a success HRESULT.
+        let owned = label.to_owned();
+        let handler = TrySuspendCompletedHandler::create(Box::new(move |result, is_successful| {
+            match result {
+                Ok(()) if is_successful => log::debug!("Suspended '{owned}' webview"),
+                Ok(()) => log::debug!("'{owned}' webview declined to suspend"),
+                Err(error) => log::warn!("Failed to suspend '{owned}' webview: {error}"),
+            }
+            Ok(())
+        }));
+        if let Err(error) = unsafe { lifecycle.TrySuspend(&handler) } {
+            log::warn!("Failed to request suspend for '{label}' webview: {error}");
+        }
+    }
+}

--- a/src/utils/tauri/player/communication.ts
+++ b/src/utils/tauri/player/communication.ts
@@ -49,9 +49,12 @@ const TIME_DRIFT_THRESHOLD_S = 0.25;
 /** Burst guard for unforced sends. */
 const TIME_MIN_GAP_MS = 30;
 // How often to reconcile the open-content-window set against the real window
-// list (to detect closes). Only runs while at least one content window is
-// believed open; opens are tracked immediately via the `slaveReady` handshake.
-const CONTENT_WINDOW_RECONCILE_MS = 2000;
+// list. Pure safety net for a dropped event: opens arrive through the
+// `slaveReady` handshake, and both ways a window can leave the set — hide and
+// destroy — are pushed by Rust as `managed-window-visibility`. Only runs while
+// at least one content window is believed open, and each pass costs one
+// `get_window_state` invoke per content label, so it stays slow on purpose.
+const CONTENT_WINDOW_RECONCILE_MS = 15_000;
 const noop = () => {};
 
 interface TimeBroadcastAnchor {
@@ -75,12 +78,12 @@ let cachedLyricSettingsKey = "";
 let cachedLyricPayload: PlayerLyricPayload | null = null;
 
 // Which content windows (mini-player / desktop-lyrics / taskbar-lyric) are
-// currently open AND visible. The 20fps time broadcast is skipped entirely
-// when this is empty, and only fans out to the labels that are actually open —
-// so the common case (no lyric/mini windows) costs nothing, and one open
-// window costs one `emitTo` instead of three. Hidden-but-alive windows count
-// as closed: Rust announces show/hide via `managed-window-visibility`, and a
-// re-shown window is healed with a full-state push.
+// currently open AND visible. The time broadcast is skipped entirely when this
+// is empty, and only fans out to the labels that are actually open — so the
+// common case (no lyric/mini windows) costs nothing, and one open window costs
+// one `emitTo` instead of three. Hidden-but-alive windows count as closed: Rust
+// announces show/hide/destroy via `managed-window-visibility`, and a re-shown
+// window is healed with a full-state push.
 const openContentWindows = new Set<string>();
 let openContentLabelsCache: string[] | null = null;
 let contentWindowReconcileTimer: ReturnType<typeof setInterval> | null = null;


### PR DESCRIPTION
启动参数（config.rs）：
- 补回被覆盖掉的 wry 默认值 msSmartScreenProtection——传 additional_browser_args 是整体替换而非追加，此前只保留了 msWebOOUI/msPdfOOUI，SmartScreen 被重新启用。
- 合并进一份 --disable-features：msEdgeAutofill/msEdgeShopping/msEdgeWallet （播放器用不到的 Edge 附加服务）、msFloatyMode（MS 文档注明 WebView2 不支持浏览器保留实验）、SpareRendererForSitePerProcess（常驻热备渲染 进程；本应用极少开新窗口，等于白占一个进程）。
- 新增 --js-flags=--scavenger_max_new_space_capacity_mb=8 与 --disk-cache-size=67108864。
- 保留硬件加速：播放器持续动画，--disable-gpu 不是可接受的取舍。
- 参数串改为 concat! 分组拼装，补两个单测防止漏空格粘连开关、防止 --disable-features 被拆成多份或丢掉 wry 默认值。

隐藏窗口策略（新增 webview_memory.rs）：
Tauri 的 window.hide() 只隐藏宿主 HWND，WebView2 controller 仍认为自己 可见，隐藏窗口照旧合成、页面仍是 visible。改为从 show/hide 路径驱动引擎侧：
- 全部受管窗口隐藏时 MemoryUsageTargetLevel::Low，显示前恢复 Normal；
- IDLE_WHEN_HIDDEN 额外 SetIsVisible(false)；
- SUSPEND_WHEN_HIDDEN（其子集，TrySuspend 要求 controller 已不可见） 再挂起渲染进程，目前只有托盘弹窗。 主窗口两个列表都不进：它是播放主控，缩到托盘时仍靠 rAF/定时器跑 AutoMix
监控与从窗口广播。预创建窗口在 on_page_load 完成后才睡——导航会自动
resume，提前挂起既会失败也会留下半加载的页面。

IPC：窗口销毁改为推送（WindowEvent::Destroyed 发 managed-window-visibility）， 主窗口的 reconcile 轮询降级为丢事件兜底，2s -> 15s。